### PR TITLE
Fix Barnet Tree Invalid Unknown entity issues

### DIFF
--- a/pipeline/tree-preservation-order/column.csv
+++ b/pipeline/tree-preservation-order/column.csv
@@ -198,3 +198,4 @@ tree,,0384db1ec63fefcb3c64275b6c942296b4220a0c9566114789f8bada92827a41,DATE_CREA
 tree,,0384db1ec63fefcb3c64275b6c942296b4220a0c9566114789f8bada92827a41,DATE_CLOSED,end-date,,,
 tree,,0384db1ec63fefcb3c64275b6c942296b4220a0c9566114789f8bada92827a41,DATE_MODIFIED,entry-date,,,
 tree,c4e4b10ec88156ebc3c47565a192ec736e6da47b5a6f4153ae56f18ff1aa0368,,WKT,geometry,,,
+tree,422e2a9f2fb1d809d8849e05556aa7c232060673c1cc51d84bcf9bb586d5de52,,tree_preservation_zone_type,tree-preservation-order-tree,,,

--- a/pipeline/tree-preservation-order/filter.csv
+++ b/pipeline/tree-preservation-order/filter.csv
@@ -1,3 +1,3 @@
 dataset,resource,field,pattern,entry-number,start-date,end-date,entry-date,endpoint
 tree-preservation-zone,,tree-preservation-zone-type,(?!Individual),,,,,422e2a9f2fb1d809d8849e05556aa7c232060673c1cc51d84bcf9bb586d5de52
-tree,,tree-preservation-zone-type,Individual,,,,,422e2a9f2fb1d809d8849e05556aa7c232060673c1cc51d84bcf9bb586d5de52
+tree,,tree-preservation-order-tree,Individual,,,,,422e2a9f2fb1d809d8849e05556aa7c232060673c1cc51d84bcf9bb586d5de52


### PR DESCRIPTION
Tree dataset seems to raise Unknown Entity Issue for TPZ entities because the filtering column is not present in Tree dataset.
This PR maps the filtering column to one that is present for Tree dataset (i.e tree-preservation-order-tree).
Finally uses the mapped column to perform the filtering.