### PR TITLE
fix broken filter config for ward dataset

### DIFF
--- a/pipeline/ward/filter.csv
+++ b/pipeline/ward/filter.csv
@@ -1,2 +1,2 @@
 dataset,resource,field,pattern,entry-number,start-date,end-date,entry-date,endpoint
-parish,,reference,"^E",,,,,
+ward,,reference,"^E",,,,,


### PR DESCRIPTION
## Data Template

**Ticket**
NA

**Type**
- [ ] New data
- [ ] Data monitoring
- [x] Data fix

**Data updated (list organisation and dataset):**
- Dataset: `ward`

**Expected outcome (if relevant):**
- [ ] New endpoint & source
- [ ] New lookups
- [x] Extra endpoint config (e.g. column, concat)
- [ ] Retired old endpoint & source
- [ ] Retired old entities
- [ ] Retired old resource

**Additional information:**
Issues are [being raised for the ward dataset](https://datasette.planning.data.gov.uk/digital-land/issue?_sort=rowid&issue_type__contains=out+of+bounds&_facet=dataset) because the dataset isn't being correctly filtered to just records in England. This fixes the incorrect dataset in the `filter.csv` config.
