### PR TITLE
add default entry-dates for all endpoints

### DIFF
--- a/pipeline/green-belt/default-value.csv
+++ b/pipeline/green-belt/default-value.csv
@@ -1,1 +1,12 @@
 dataset,end-date,endpoint,entry-date,entry-number,field,resource,start-date,value
+green-belt,,58f8ec82cc59a963cc9915e12eda358738d31b348413fc79cb19b5fe5b7ad930,,,entry-date,,,2014-12-01
+green-belt,,14d9d98a67683dfa834cc9e7f50c9fed515df298d3bb17f776d73aa9e58f6b23,,,entry-date,,,2015-12-01
+green-belt,,48b3108adbdd0c3838dc1859038dac22fc2034eb40e60c4750e38d1e2a420d22,,,entry-date,,,2016-12-01
+green-belt,,cfb150d6d575fc78562b43faa7483d62cce71b80ad16779320a879f2626eff43,,,entry-date,,,2017-12-01
+green-belt,,5cf30af559859b8e01088a0765f5864115ff3fe5504508168f10429fe38c383f,,,entry-date,,,2018-12-01
+green-belt,,cbe952dd437d085d8c630d86632924693bac236c4fbad92cfdb623db3313e564,,,entry-date,,,2019-12-01
+green-belt,,21f6ac0160488dfdab4fae54bea1940ec2827e9c80d3b8df7ea73a45229c000f,,,entry-date,,,2020-12-01
+green-belt,,b04c507f53aa0e0624b5f529c3335413f1ea384674533f910ba5ad24baa0464b,,,entry-date,,,2021-12-01
+green-belt,,e00db39f56de236656d4c5c9bb81923dbd0bf31a216ec2bb2020cee1e4242ebf,,,entry-date,,,2022-12-01
+green-belt,,0a348ac5a298612f216088f285ab4fd049752bd663f058e0801e8c70c0cf7717,,,entry-date,,,2023-12-01
+green-belt,,97bbf2577ae07bc9ef6551d7ec38a8dd764de04f2f702ca2a1c1764d3fbb175b,,,entry-date,,,2024-12-01


### PR DESCRIPTION
## Data Template

**Ticket**
https://github.com/digital-land/digital-land-python/issues/382

**Type**
- [ ] New data
- [ ] Data monitoring
- [x] Data fix

**Data updated (list organisation and dataset):**
- Dataset: `green-belt`

**Expected outcome (if relevant):**
- [ ] New endpoint & source
- [ ] New lookups
- [x] Extra endpoint config (e.g. column, concat)
- [ ] Retired old endpoint & source
- [ ] Retired old entities
- [ ] Retired old resource

**Additional information:**


**Requester's checklist:**
- [ ] Have checked if any old endpoints to retire
- [ ] Have validated endpoint (with check or endpoint checker)
- [ ] Have checked expected number of lookups
- [ ] Have checked for any geo duplicates (if CA data)
- [ ] Have updated entity-organisation.csv (if CA data)

**Reviewer's checklist:**
- [ ] Expected checks have been completed by PR requester
- [ ] Correct date format used in config files (YYYY-mm-dd)
- [ ] Number of new lookups is as expected from source data
- [ ] Spot checked that newly assigned entity numbers aren’t in use
