### PR TITLE
udpate batch_assign_entities to check new entities before assinging

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,32 @@
+name: Continuous Integration
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Make Init
+      run: |
+        make init
+    - name: Lint, Test, Coverage
+      run: |
+        make
+    - name: Publish Test Report
+      uses: mikepenz/action-junit-report@v4
+      if: always() # always run even if the previous step fails
+      with:
+        report_paths: '.junitxml/*.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest
-        pip install pytest-mock
-   
+       
     - name: Run Tests
       run: make test
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: Test
 on:
   push:
   workflow_dispatch:
@@ -15,18 +15,22 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Make Init
+
+    - name: Install dependencies
       run: |
-        make init
-    - name: Lint, Test, Coverage
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pytest  # Explicitly install pytest
+        pip install pytest-mock
+    - name: Check pytest
       run: |
-        make
-    - name: Publish Test Report
-      uses: mikepenz/action-junit-report@v4
-      if: always() # always run even if the previous step fails
-      with:
-        report_paths: '.junitxml/*.xml'
+        pip show pytest || echo "pytest not installed"
+    - name: Run Tests
+      run: make test
+      env:
+        COLLECTION: dummy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest  # Explicitly install pytest
+        pip install pytest
         pip install pytest-mock
-    - name: Check pytest
-      run: |
-        pip show pytest || echo "pytest not installed"
+   
     - name: Run Tests
       run: make test
       env:

--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,11 @@ ifeq ($(INPUT_CSV),)
 	@exit 1
 endif
 	digital-land add-data $(INPUT_CSV) $(COLLECTION) -c $(COLLECTION_DIR) -p $(PIPELINE_DIR) -o $(CACHE_DIR)organisation.csv
+
+test:: test-unit test-integration
+
+test-unit:
+	pytest tests/unit/
+
+test-integration:
+	pytest tests/integration/

--- a/batch_assign_entities.py
+++ b/batch_assign_entities.py
@@ -27,7 +27,7 @@ def get_field_value_map(df, entity_number):
     """
     returns a dict of of field-value pairs for a given entity from transformed file
     """
-    sub_df = df[(df['entity'] == entity_number) & (df['field'] != 'reference')]
+    sub_df = df[(df['entity'] == entity_number) & (df['field'] != 'reference') & (df['field'] != 'entry-date')]
     return dict(zip(sub_df['field'], sub_df['value']))
 
 

--- a/bin/batch_assign_entities.py
+++ b/bin/batch_assign_entities.py
@@ -78,6 +78,8 @@ def process_csv(scope):
                     failed_downloads.append((row_number, resource, str(e)))
                     continue
                 collection_path = Path(f"collection/{collection_name}")
+
+                input_path = Path(cache_dir / "assign_entities" / "transformed" / f"{resource}.csv")
                 try:
                     check_and_assign_entities(
                         [resource_path],
@@ -89,6 +91,7 @@ def process_csv(scope):
                         cache_dir / "organisation.csv",
                         Path("specification"),
                         Path(f"pipeline/{collection_name}"),
+                        input_path,
                     )
 
                     #get old transformed resource
@@ -96,7 +99,6 @@ def process_csv(scope):
 
                     # get current transformed resource
                     current_resource_df = pd.read_csv(cache_dir / "assign_entities" / "transformed" / f"{resource}.csv")
-                    #old_resource_df = pd.read_csv(os.path.join("var/cache/assign_entities/transformed", "second_resource.csv"))
                     
                     current_entities = set(current_resource_df['entity'])
                     old_entities = set(old_resource_df['entity'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 -e git+https://github.com/digital-land/digital-land-python.git#egg=digital-land
+pytest
+pytest-mock

--- a/tests/integration/test_process_csv.py
+++ b/tests/integration/test_process_csv.py
@@ -105,6 +105,7 @@ def test_process_csv_match_entities(
             raise ValueError("Unexpected URL")
 
     monkeypatch.setattr(batch_assign_entities.requests, "get", mock_get_match_entities)
+    monkeypatch.setattr(batch_assign_entities, "check_and_assign_entities", lambda *args, **kwargs: True)
 
     failed_downloads, failed_assignments = batch_assign_entities.process_csv(scope="odp")
     out, err = capfd.readouterr()
@@ -139,6 +140,7 @@ def test_process_csv_success(
             raise ValueError("Unexpected URL")
 
     monkeypatch.setattr(batch_assign_entities.requests, "get", mock_get_success)
+    monkeypatch.setattr(batch_assign_entities, "check_and_assign_entities", lambda *args, **kwargs: True)
 
     failed_downloads, failed_assignments = batch_assign_entities.process_csv(scope="odp")
     out, err = capfd.readouterr()

--- a/tests/integration/test_process_csv.py
+++ b/tests/integration/test_process_csv.py
@@ -76,7 +76,7 @@ class MockResponse:
         self.status_code = status_code
 
     def raise_for_status(self):
-        if not 200:
+        if self.status_code != 200:
             raise requests.HTTPError("error")
 
     @property

--- a/tests/integration/test_process_csv.py
+++ b/tests/integration/test_process_csv.py
@@ -1,0 +1,152 @@
+import requests
+import pytest
+import bin.batch_assign_entities as batch_assign_entities
+
+
+@pytest.fixture
+def setup_test_path(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "collection/test-collection").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "specification").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "pipeline/test-collection").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "var/cache/organisation.csv").parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "var/cache/organisation.csv").write_text("organisation\n")
+
+    (tmp_path / "var/cache/assign_entities/test-collection/pipeline").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "var/cache/assign_entities/test-collection/pipeline/lookup.csv").write_text("lookups")
+
+    # mock check_and_assign_entities
+    monkeypatch.setattr(batch_assign_entities, "check_and_assign_entities", lambda *args, **kwargs: None)
+
+
+@pytest.fixture
+def mock_user_response(monkeypatch):
+    monkeypatch.setattr(batch_assign_entities, "get_user_response", lambda _: "no")
+
+
+@pytest.fixture
+def mock_resource_files(tmp_path):
+    cache_dir = tmp_path / "var/cache/assign_entities/transformed"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    
+    success_resource = """entity,field,value
+10,name,test_name
+10,reference,ref1
+10,geometry,POINT()
+"""
+    (cache_dir / "test-resource.csv").write_text(success_resource)
+
+    success_old_resource = """entity,field,value
+1,name,old_name
+1,reference,ref1
+1,geometry,POINT()
+"""
+    
+    failure_resource = """entity,field,value
+10,name,test_name
+10,reference,ref10
+10,geometry,POINT()
+"""
+    failure_old_resource = """entity,field,value
+1,name,test_name
+1,reference,ref1
+1,geometry,POINT()
+"""
+
+    return {
+        "success": {"resource": success_resource, "old_resource": success_old_resource},
+        "failure": {"resource": failure_resource, "old_resource": failure_old_resource}
+    }
+
+@pytest.fixture
+def mock_issue_summary(tmp_path):
+    # create mock issue_summary.csv
+    content = """issue_type,scope,dataset,collection,resource,endpoint,pipeline,organisation
+unknown entity,odp,article-4-direction,test-collection,test-resource,test-endpoint,test-dataset,test-org
+"""
+    issue_summary_path = tmp_path / "issue_summary.csv"
+    issue_summary_path.write_text(content)
+    return issue_summary_path
+
+
+class MockResponse:
+    def __init__(self, text_data, status_code=200):
+        self.text = text_data
+        self._content = text_data.encode('utf-8')
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if not 200:
+            raise requests.HTTPError("error")
+
+    @property
+    def content(self):
+        return self._content
+        
+
+def test_process_csv_match_entities(
+    capfd, 
+    setup_test_path, 
+    mock_user_response, 
+    mock_resource_files, 
+    mock_issue_summary,
+    monkeypatch,
+    tmp_path,
+):
+    
+    def mock_get_match_entities(url, *args, **kwargs):
+        if "reporting_historic_endpoints.csv" in url:
+            return MockResponse('resource\nold-hash\n')
+        elif "old-hash.csv" in url:
+            return MockResponse(mock_resource_files["failure"]["old_resource"])
+        elif "collection/resource/test-resource" in url:
+            return MockResponse("resource")
+        else:
+            raise ValueError("Unexpected URL")
+
+    monkeypatch.setattr(batch_assign_entities.requests, "get", mock_get_match_entities)
+
+    failed_downloads, failed_assignments = batch_assign_entities.process_csv(scope="odp")
+    out, err = capfd.readouterr()
+
+    assert failed_downloads == []
+    assert failed_assignments == []
+    assert "Downloaded: test-resource" in out
+    assert "Matching entities found (new_entity:matched_current_entity): {10: 1}" in out
+
+    resources_dir = tmp_path / "resource"
+    assert not any(resources_dir.glob("*")), "Resource file still exists"
+
+
+def test_process_csv_success(
+    capfd, 
+    setup_test_path, 
+    mock_user_response, 
+    mock_resource_files, 
+    mock_issue_summary, 
+    monkeypatch,
+    tmp_path,
+):
+
+    def mock_get_success(url, *args, **kwargs):
+        if "reporting_historic_endpoints.csv" in url:
+            return MockResponse('resource\nold-hash\n')
+        elif "old-hash.csv" in url:
+            return MockResponse(mock_resource_files["success"]["old_resource"])
+        elif "collection/resource/test-resource" in url:
+            return MockResponse("resource")
+        else:
+            raise ValueError("Unexpected URL")
+
+    monkeypatch.setattr(batch_assign_entities.requests, "get", mock_get_success)
+
+    failed_downloads, failed_assignments = batch_assign_entities.process_csv(scope="odp")
+    out, err = capfd.readouterr()
+
+    assert failed_downloads == []
+    assert failed_assignments == []
+    assert "Downloaded: test-resource" in out
+    assert "Matching entities found" not in out
+
+    updated_lookup = tmp_path / "pipeline/test-collection/lookup.csv"
+    assert updated_lookup.exists(), "Updated lookup.csv should exist after success"

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -1,0 +1,56 @@
+import pytest
+import pandas as pd
+
+from bin.batch_assign_entities import get_field_value_map, get_old_resource_df, get_scope
+
+
+def test_get_field_value_map():
+    data = {
+        'entity': [1, 1, 1, 1, 2, 2, 2, 2],
+        'field': ['name', 'geometry', 'reference', 'entry-date', 'name', 'geometry' , 'reference', 'entry-date'],
+        'value': ['CA1_name', 'POINT()', 'ref1', '2025-01-01', 'CA2_name', 'MULTIPOLYGON()', 'ref2', '2025-01-01']
+    }
+    df = pd.DataFrame(data)
+    result = get_field_value_map(df, 1)
+    assert result == {'name': 'CA1_name', 'geometry': 'POINT()'}
+    assert 'reference' and 'entry-date' not in result
+
+    result = get_field_value_map(df, 2)
+    assert result == {'name': 'CA2_name', 'geometry': 'MULTIPOLYGON()'}
+    assert 'reference' and 'entry-date' not in result
+
+
+def test_get_old_resource_df(mocker):
+    
+    mock_response = mocker.MagicMock()
+    mock_response.text = "resource\nresource_hash\n"
+
+    mock_response_transformed = mocker.MagicMock()
+    mock_response_transformed.text = (
+        "entity,field,value\n"
+        "1,name,test_name\n"
+        "1,geometry,POINT()\n"
+        "1,reference,ref1"
+    )
+    mocker.patch("bin.batch_assign_entities.requests.get", side_effect=[mock_response, mock_response_transformed])
+    df = get_old_resource_df("test-endpoint", "test-collection", "test-dataset")
+
+    assert isinstance(df, pd.DataFrame)
+    assert list(df.columns) == ["entity", "field", "value"]
+    
+    expected_fields = ["name", "geometry", "reference"]
+    expected_values = ["test_name", "POINT()", "ref1"]
+
+    assert df["field"].tolist() == expected_fields
+    assert df["value"].tolist() == expected_values
+
+
+def test_get_scope():
+    scope_dict = {
+        "odp": ["conservation-area", "article-4-direction"],
+        "mandated": ["brownfield-land", "developer-contributions"],
+    }
+
+    assert get_scope("article-4-direction",scope_dict) == "odp"
+    assert get_scope("brownfield-land",scope_dict) == "mandated"
+    assert get_scope("ancient-woodland",scope_dict) == "single-source"


### PR DESCRIPTION
## Data Template

**Ticket**
- Link: https://github.com/digital-land/config/issues/535

**Type**
- [ ] New data
- [x] Data monitoring
- [ ] Data fix

**Additional information:**
Modifies `batch_assign_script` to update the process for assigning entities.
It uses the transformed files to compare the entities, gets the transformed file for current resource using `check_and_assign_entities` and second latest resource from the CDN using datasette.
Prints a message when a matching entity is found, for this it uses all fields except reference.
If there are matching entities found then the script asks the user if they still want to assign entities despite of a match found.

Also, adds a workflow file called test.yml to run tests 
Makes use of `test-unit` and `test-integration` rules in makefile