### PR TITLE
retired-one-entity for Chichester District Council

### DIFF
--- a/pipeline/conservation-area/old-entity.csv
+++ b/pipeline/conservation-area/old-entity.csv
@@ -3351,3 +3351,4 @@ old-entity,status,entity,end-date,notes,entry-date,start-date
 44006551,301,44010603,,redirect Historic England duplicate to LPA entity,2025-03-25,
 44006552,301,44010620,,redirect Historic England duplicate to LPA entity,2025-03-25,
 44000677,301,44013322,,redirect Historic England duplicate to LPA entity,2025-05-13,
+44009107,410,,,wrong data was added in 2020 for Chichester District Council,,


### PR DESCRIPTION
wrong data was added in 2020 for Chichester District Council

## Data Template

**Ticket**
- Link: 

**Type**
- [ ] New data
- [ ] Data monitoring
- [x] Data fix

**Data updated (list organisation and dataset):**
- Dataset:

**Expected outcome (if relevant):**
- [ ] New endpoint & source
- [ ] New lookups
- [ ] Extra endpoint config (e.g. column, concat)
- [ ] Retired old endpoint & source
- [x] Retired old entities
- [ ] Retired old resource

**Additional information:**
- Any other relevant details or considerations.

**Requester's checklist:**
- [ ] Have checked if any old endpoints to retire
- [ ] Have validated endpoint (with check or endpoint checker)
- [ ] Have checked expected number of lookups
- [ ] Have checked for any geo duplicates (if CA data)
- [ ] Have updated entity-organisation.csv (if CA data)

**Reviewer's checklist:**
- [ ] Expected checks have been completed by PR requester
- [ ] Correct date format used in config files (YYYY-mm-dd)
- [ ] Number of new lookups is as expected from source data
- [ ] Spot checked that newly assigned entity numbers aren’t in use
