### PR TITLE
Stop slow-running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
We noticed our CI pipeline was taking an unacceptable amount of time to run tests against Python 3.8 as DuckDB was taking over 10 minutes to install on 3.8. The same test on Python 3.9 completes in under a minute. We have turned the test off in version 3.8 so that it only runs on 3.9 to increase the speed of our tests.
