### PR TITLE
fix collection name from central-activity-zone to central-activities-zone

### DIFF
--- a/collection/central-activities-zone/source.csv
+++ b/collection/central-activities-zone/source.csv
@@ -1,4 +1,4 @@
 source,attribution,collection,documentation-url,endpoint,licence,organisation,pipelines,entry-date,start-date,end-date
 69b4b590dcd98d2bbba0edeb589b5301,,central-activities-zone,https://lambethopenmappingdata-lambethcouncil.opendata.arcgis.com/datasets/lambethcouncil::central-activities-zone-1/about,7b4b9b400899e33b81a52c5893987827666437d1fcc8488d610d0ae77b605a31,ogl3,local-authority:LBH,central-activities-zone,2021-10-29T10:10:36Z,2020-12-17,
-e73ddd594e4679d921cb9e4939807466,,central-activity-zone,https://data.london.gov.uk/dataset/central_activities_zone,7bc8a737cf2fc696b33985d1112421cbf09eb8236192f298d971ab01808f8378,,local-authority:GLA,central-activities-zone,2021-11-11T15:15:58Z,,
+e73ddd594e4679d921cb9e4939807466,,central-activities-zone,https://data.london.gov.uk/dataset/central_activities_zone,7bc8a737cf2fc696b33985d1112421cbf09eb8236192f298d971ab01808f8378,,local-authority:GLA,central-activities-zone,2021-11-11T15:15:58Z,,
 5aef35592b74f29774dd2ef4a1e857ea,,central-activities-zone,,8e4b3785e5b478804603d297d147b073589ddc532b179edfc9cd38f166f7b364,ogl3,local-authority:SWK,central-activities-zone,2021-11-30T17:17:52Z,,


### PR DESCRIPTION
## Data Template

**Ticket**
- Link: 

**Type**
- [ ] New data
- [ ] Data monitoring
- [x] Data fix

**Data updated (list organisation and dataset):**
- Dataset:

**Expected outcome (if relevant):**
- [ ] New endpoint & source
- [ ] New lookups
- [ ] Extra endpoint config (e.g. column, concat)
- [ ] Retired old endpoint & source
- [ ] Retired old entities
- [ ] Retired old resource

**Additional information:**
- Any other relevant details or considerations.

**Requester's checklist:**
- [ ] Have checked if any old endpoints to retire
- [ ] Have validated endpoint (with check or endpoint checker)
- [ ] Have checked expected number of lookups
- [ ] Have checked for any geo duplicates (if CA data)
- [ ] Have updated entity-organisation.csv (if CA data)

**Reviewer's checklist:**
- [ ] Expected checks have been completed by PR requester
- [ ] Correct date format used in config files (YYYY-mm-dd)
- [ ] Number of new lookups is as expected from source data
- [ ] Spot checked that newly assigned entity numbers aren’t in use
