### PR TITLE
update invalid org for camden

### DIFF
--- a/pipeline/central-activities-zone/patch.csv
+++ b/pipeline/central-activities-zone/patch.csv
@@ -8,3 +8,4 @@ resource,field,pattern,value,dataset,entry-number,start-date,end-date,entry-date
 ,organisation,tower hamlets,local-authority:TWH,central-activities-zone,,,,,7bc8a737cf2fc696b33985d1112421cbf09eb8236192f298d971ab01808f8378
 ,organisation,islington,local-authority:ISL,central-activities-zone,,,,,7bc8a737cf2fc696b33985d1112421cbf09eb8236192f298d971ab01808f8378
 ,organisation,hackney,local-authority:HCK,central-activities-zone,,,,,7bc8a737cf2fc696b33985d1112421cbf09eb8236192f298d971ab01808f8378
+,organisation,camden,local-authority:CMD,central-activities-zone,,,,,7bc8a737cf2fc696b33985d1112421cbf09eb8236192f298d971ab01808f8378


### PR DESCRIPTION
## Data Template

**Ticket**
- Link: https://github.com/digital-land/config/issues/933

**Type**
- [ ] New data
- [ ] Data monitoring
- [X] Data fix

**Data updated (list organisation and dataset):**
- Dataset:

**Expected outcome (if relevant):**
- [ ] New endpoint & source
- [ ] New lookups
- [ ] Extra endpoint config (e.g. column, concat)
- [ ] Retired old endpoint & source
- [ ] Retired old entities
- [ ] Retired old resource

**Additional information:**
- Any other relevant details or considerations.

**Requester's checklist:**
- [ ] Have checked if any old endpoints to retire
- [ ] Have validated endpoint (with check or endpoint checker)
- [ ] Have checked expected number of lookups
- [ ] Have checked for any geo duplicates (if CA data)
- [ ] Have updated entity-organisation.csv (if CA data)

**Reviewer's checklist:**
- [ ] Expected checks have been completed by PR requester
- [ ] Correct date format used in config files (YYYY-mm-dd)
- [ ] Number of new lookups is as expected from source data
- [ ] Spot checked that newly assigned entity numbers aren’t in use
