### PR TITLE
Remove old resource entry from old-resource.csv

### DIFF
--- a/collection/brownfield-land/old-resource.csv
+++ b/collection/brownfield-land/old-resource.csv
@@ -38,5 +38,4 @@ ec1ff31625d546423b174d6e6eafca40efa4f10525199b0cbc6990ceb7d748a9,410,,LPA COV as
 ca82001e45f814ebfdcbce31b7f6774221d68b6f33bdb5c2b9223dd0100cc542,410,,LPA COV asked to remove old resources
 0a4c0d56fe077f2b4701a9a2ab1d18ab37ae0f6b37cab10170020209deceee40,410,,LPA WYC asked to remove old resources
 8f17ef782338a522bba007658eb0bf20571e8e7a69246fa5585f939475f8e999,410,,LPA WYC asked to remove old resources
-fed41014d16617d787676b57c7668ac5436c14a259b1a76fe3806a86a29fe092,410,,LPA WYC asked to remove old resources
 6f2170139c063786cb4d9d881ed7806947fcdcd9698823259a0cfa3f09f7317f,410,,LPA WYC asked to remove old resources


### PR DESCRIPTION
Removed an old resource entry from the CSV file.

## Data Template

**Ticket**
- Link: 

**Type**
- [ ] New data
- [ ] Data monitoring
- [ ] Data fix

**Data updated (list organisation and dataset):**
- Dataset:

**Expected outcome (if relevant):**
- [ ] New endpoint & source
- [ ] New lookups
- [ ] Extra endpoint config (e.g. column, concat)
- [ ] Retired old endpoint & source
- [ ] Retired old entities
- [ ] Retired old resource

**Additional information:**
- Any other relevant details or considerations.

**Requester's checklist:**
- [ ] Have checked if any old endpoints to retire
- [ ] Have validated endpoint (with check or endpoint checker)
- [ ] Have checked expected number of lookups
- [ ] Have checked for any geo duplicates (if CA data)
- [ ] Have updated entity-organisation.csv (if CA data)

**Reviewer's checklist:**
- [ ] Expected checks have been completed by PR requester
- [ ] Correct date format used in config files (YYYY-mm-dd)
- [ ] Number of new lookups is as expected from source data
- [ ] Spot checked that newly assigned entity numbers aren’t in use
