### PR TITLE
Fix incorrect end_date for entity 309 in CSV

### DIFF
--- a/collection/organisation/old-resource.csv
+++ b/collection/organisation/old-resource.csv
@@ -175,3 +175,4 @@ e11c68c5d2d0e2b91adf56e153ed539aa167e4c449a717eb9d7aded8a000f749,410,,
 beaac071c85690f303c872dcdd53fff6bf8498bcb328e09390d6b36306f0a117,410,,resource retaining old wrong value for local-planning-authority
 c5d7855d378c955477f43c251bd1c92da2dd221664152e1643d0338c420aa306,410,,resource retaining old wrong value for local-planning-authority
 1df35581959e0de0b56b3768ee3cc539c5c0d65244abb3302504e138ad43a3d2,410,,resource retaining old wrong value for local-planning-authority
+08cab10e96835b7d874b1d9b58882946436448efa1cd3d5ca6e29215498f76dd,410,,incorrect end_date in resource for entity 309


### PR DESCRIPTION
## Data Template

**Ticket**
- Link: 

**Type**
- [ ] New data
- [ ] Data monitoring
- [ ] Data fix

**Data updated (list organisation and dataset):**
- Dataset:

**Expected outcome (if relevant):**
- [ ] New endpoint & source
- [ ] New lookups
- [ ] Extra endpoint config (e.g. column, concat)
- [ ] Retired old endpoint & source
- [ ] Retired old entities
- [ ] Retired old resource

**Additional information:**
- Any other relevant details or considerations.

**Requester's checklist:**
- [ ] Have checked if any old endpoints to retire
- [ ] Have validated endpoint (with check or endpoint checker)
- [ ] Have checked expected number of lookups
- [ ] Have checked for any geo duplicates (if CA data)
- [ ] Have updated entity-organisation.csv (if CA data)

**Reviewer's checklist:**
- [ ] Expected checks have been completed by PR requester
- [ ] Correct date format used in config files (YYYY-mm-dd)
- [ ] Number of new lookups is as expected from source data
- [ ] Spot checked that newly assigned entity numbers aren’t in use
