### PR TITLE
pr body showing wrong info

### DIFF
--- a/.github/workflows/add-data-rest-api.yml
+++ b/.github/workflows/add-data-rest-api.yml
@@ -171,7 +171,7 @@ jobs:
 
           # Create PR
           if [ -n "$TRIGGERED_BY" ]; then
-            gh pr create --title "$PR_TITLE" --body "$(cat <<'PRBODY'
+            gh pr create --title "$PR_TITLE" --body "$(cat <<PRBODY
           Collection: $COLLECTION
           Triggered by: $TRIGGERED_BY
 
@@ -179,7 +179,7 @@ jobs:
           PRBODY
           )" --base main --head "$BRANCH_NAME"
           else
-            gh pr create --title "$PR_TITLE" --body "$(cat <<'PRBODY'
+            gh pr create --title "$PR_TITLE" --body "$(cat <<PRBODY
           Collection: $COLLECTION
 
           This PR was automatically created via the REST API.


### PR DESCRIPTION
## Data Template

**Ticket**
- Link: 

**Type**
- [ ] New data
- [ ] Data monitoring
- [ ] Data fix

**Data updated (list organisation and dataset):**
- Dataset:

**Expected outcome (if relevant):**
- [ ] New endpoint & source
- [ ] New lookups
- [ ] Extra endpoint config (e.g. column, concat)
- [ ] Retired old endpoint & source
- [ ] Retired old entities
- [ ] Retired old resource

**Additional information:**
- Any other relevant details or considerations.

**Requester's checklist:**
- [ ] Have checked if any old endpoints to retire
- [ ] Have validated endpoint (with check or endpoint checker)
- [ ] Have checked expected number of lookups
- [ ] Have checked for any geo duplicates (if CA data)
- [ ] Have updated entity-organisation.csv (if CA data)

**Reviewer's checklist:**
- [ ] Expected checks have been completed by PR requester
- [ ] Correct date format used in config files (YYYY-mm-dd)
- [ ] Number of new lookups is as expected from source data
- [ ] Spot checked that newly assigned entity numbers aren’t in use
