### PR TITLE
remove crlf from file

### DIFF
--- a/pipeline/conservation-area/entity-organisation.csv
+++ b/pipeline/conservation-area/entity-organisation.csv
@@ -1959,5 +1959,4 @@ conservation-area-document,6313894,6314026,national-park-authority:Q72617158
 conservation-area-document,6310267,6310283,national-park-authority:Q72617669
 conservation-area-document,6310487,6310520,national-park-authority:Q72617784
 conservation-area-document,6310521,6310738,national-park-authority:Q72617988
-
 conservation-area,44014994,44015013,local-authority:EXE


### PR DESCRIPTION
A mix up of CRLF line endings an LF line endings in this file causes the tests to get confused, it seems to only be this file that has this problem, so by removing and converting to LF all future workflows appends by the API using LF should work.