### PR TITLE
Update retire-mhclg-ca-data.py

### DIFF
--- a/.github/scripts/retire-mhclg-ca-data.py
+++ b/.github/scripts/retire-mhclg-ca-data.py
@@ -58,50 +58,121 @@ def execute_datasette_query(database, sql):
     return all_rows
 
 
-def get_odp_organisations():
-    """Load and return set of organisations in the Open Digital Planning programme."""
-    print("Loading ODP organisations from provision table...")
+def get_odp_organisations_for_dataset(dataset_name):
+    """Load and return set of ODP organisations that have provided a specific dataset."""
     try:
-        sql = """
+        sql = f"""
             SELECT DISTINCT organisation
             FROM provision
             WHERE project = 'open-digital-planning'
+            AND dataset = '{dataset_name}'
         """
         rows = execute_datasette_query('digital-land', sql)
         odp_orgs = set(row['organisation'] for row in rows)
-        print(f"Found {len(odp_orgs)} organisations in ODP")
+        print(f"Found {len(odp_orgs)} ODP organisations with {dataset_name} dataset")
         return odp_orgs
     except Exception as e:
-        print(f"Error loading ODP organisations: {e}")
+        print(f"Error loading ODP organisations for {dataset_name}: {e}")
         raise
 
 
-def get_ca_endpoints_in_odp(odp_orgs):
-    """Fetch historic endpoints and filter for CA datasets in ODP organisations."""
-    print("Loading historic endpoints...")
+def get_endpoints_by_dataset(dataset_name):
+    """Fetch MHCLG endpoints where ACTIVE authoritative LPA data also exists.
+
+    For each LPA, check if there is BOTH:
+    - MHCLG data (organisation='government-organisation:D1342')
+    - ACTIVE authoritative data from LPA (organisation != 'government-organisation:D1342' AND endpoint_end_date is empty)
+
+    Only retire MHCLG endpoints for LPAs that have both sources, and where the authoritative data is still active.
+    """
+    print(f"\nProcessing {dataset_name} dataset...")
     try:
-        sql = """
-            SELECT *
+        # Get ALL endpoints for this dataset (not filtered by organisation)
+        sql = f"""
+            SELECT endpoint, endpoint_url, organisation, endpoint_end_date
             FROM reporting_historic_endpoints
-            WHERE dataset IN ('conservation-area', 'conservation-area-document')
+            WHERE pipeline = '{dataset_name}'
         """
         all_rows = execute_datasette_query('performance', sql)
-        print(f"Loaded {len(all_rows)} endpoints")
+        print(f"Loaded {len(all_rows)} total {dataset_name} endpoints")
 
-        # Extract organisation code and check if in ODP
-        endpoints_in_odp = []
+        # Group by LPA/organisation code
+        endpoints_by_lpa = {}
         for row in all_rows:
-            endpoint_url = row.get('endpoint_url', '')
-            # Extract org code from URL (e.g., https://.../camden-... -> camden)
-            org_code = 'local-authority:' + endpoint_url.split('/')[-1].split('-')[0]
+            org = row.get('organisation', '')
 
-            if org_code in odp_orgs:
-                endpoints_in_odp.append(row)
+            # Skip Historic England (never retire their data)
+            if org == 'government-organisation:PB1164':
+                continue
 
-        print(f"Found {len(endpoints_in_odp)} endpoints in ODP organisations")
-        return endpoints_in_odp
+            # Extract organisation/LPA code
+            # MHCLG: extract from URL (e.g., ADU-conservation-area.csv -> ADU)
+            # Others: use organisation code (local-authority:ADU, national-park:*, development-corporation:*, etc.)
+            if org == 'government-organisation:D1342':
+                endpoint_url = row.get('endpoint_url', '')
+                lpa_code = endpoint_url.split('/')[-1].split('-')[0]
+            else:
+                # For local-authority, national-park, development-corporation, etc.
+                # Extract the code after the colon (e.g., local-authority:ADU -> ADU)
+                if ':' in org:
+                    lpa_code = org.split(':')[1]
+                else:
+                    # Skip if can't parse
+                    continue
+
+            if lpa_code not in endpoints_by_lpa:
+                endpoints_by_lpa[lpa_code] = {'mhclg': [], 'authoritative_active': [], 'authoritative_retired': []}
+
+            if org == 'government-organisation:D1342':
+                endpoints_by_lpa[lpa_code]['mhclg'].append(row)
+            else:
+                # Separate active and retired authoritative endpoints
+                if row.get('endpoint_end_date'):
+                    endpoints_by_lpa[lpa_code]['authoritative_retired'].append(row)
+                else:
+                    endpoints_by_lpa[lpa_code]['authoritative_active'].append(row)
+
+        # Find LPAs with both MHCLG and ACTIVE authoritative data
+        endpoints_to_retire = []
+        lpas_with_both = set()
+        mhclg_only = 0
+        auth_only_active = 0
+        auth_only_retired = 0
+        for lpa, data in endpoints_by_lpa.items():
+            has_mhclg = len(data['mhclg']) > 0
+            has_auth_active = len(data['authoritative_active']) > 0
+            has_auth_retired = len(data['authoritative_retired']) > 0
+
+            if has_mhclg and has_auth_active:
+                # Only retire MHCLG if active authoritative alternative exists
+                endpoints_to_retire.extend(data['mhclg'])
+                lpas_with_both.add(lpa)
+            elif has_mhclg and not has_auth_active:
+                # MHCLG-only: keep it (no active alternative)
+                mhclg_only += 1
+            elif not has_mhclg and has_auth_active:
+                # Active authoritative-only
+                auth_only_active += 1
+            elif not has_mhclg and has_auth_retired:
+                # Retired authoritative-only
+                auth_only_retired += 1
+
+        print(f"Found {len(lpas_with_both)} LPAs with both MHCLG and ACTIVE authoritative data")
+        print(f"  MHCLG-only LPAs: {mhclg_only}")
+        print(f"  Active authoritative-only LPAs: {auth_only_active}")
+        print(f"  Retired authoritative-only LPAs: {auth_only_retired}")
+        print(f"Retiring {len(endpoints_to_retire)} MHCLG {dataset_name} endpoints")
+
+        # Debug: show sample data if nothing to retire
+        if len(endpoints_to_retire) == 0 and len(all_rows) > 0:
+            print(f"\nDEBUG: Sample endpoints from {dataset_name}:")
+            for i, row in enumerate(all_rows[:3]):
+                print(f"  [{i}] endpoint_url: {row.get('endpoint_url', 'N/A')[:80]}")
+                print(f"      organisation: {row.get('organisation', 'N/A')}")
+
+        return endpoints_to_retire, lpas_with_both
     except Exception as e:
-        print(f"Error loading endpoints: {e}")
+        print(f"Error loading {dataset_name} endpoints: {e}")
         raise
 
 
@@ -115,12 +186,13 @@ def update_csv_with_end_dates(file_path, endpoints_to_retire):
             fieldnames = reader.fieldnames
             rows = list(reader)
 
-        # Update end-dates for matching endpoints
+        # Update end-dates for matching endpoints that haven't been retired yet
         today = datetime.now().strftime('%Y-%m-%d')
         updated_count = 0
 
         for row in rows:
-            if row.get('endpoint') in endpoints_to_retire:
+            # Only update if endpoint matches AND it doesn't already have an end-date
+            if row.get('endpoint') in endpoints_to_retire and not row.get('end-date'):
                 row['end-date'] = today
                 updated_count += 1
 
@@ -155,9 +227,20 @@ def update_endpoint_dates(endpoints_in_odp):
 
 
 def get_resources_for_retirement(endpoints_in_odp):
-    """Fetch resource data and extract resources for endpoints being retired."""
+    """Fetch resource data for endpoints being retired.
+
+    Excludes resources that are already in old-resource.csv to avoid
+    adding duplicate retirement records.
+    """
     print("Loading resource data...")
     try:
+        # Read old-resource.csv to get list of already-retired resources
+        already_retired_resources = set()
+        with open(OLD_RESOURCE_PATH, 'r', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                already_retired_resources.add(row.get('old-resource'))
+
         sql = """
             SELECT *
             FROM reporting_historic_endpoints
@@ -165,11 +248,13 @@ def get_resources_for_retirement(endpoints_in_odp):
         all_rows = execute_datasette_query('performance', sql)
         print(f"Loaded {len(all_rows)} resource records")
 
-        # Get resources for endpoints we're retiring
+        # Get resources for endpoints we're retiring (excluding those already in old-resource.csv)
         endpoints_set = set(row.get('endpoint') for row in endpoints_in_odp)
         resources_to_retire = [
             row.get('resource') for row in all_rows
-            if row.get('endpoint') in endpoints_set and row.get('resource')
+            if row.get('endpoint') in endpoints_set
+            and row.get('resource')
+            and row.get('resource') not in already_retired_resources
         ]
 
         print(f"Found {len(resources_to_retire)} resources to retire")
@@ -217,27 +302,71 @@ def update_old_resource_csv(resources_to_retire):
 
 
 def main():
-    """Main execution function."""
+    """Main execution function.
+
+    Processes conservation-area and conservation-area-document datasets separately.
+    For each dataset, retires MHCLG endpoints where authoritative LPA data also exists.
+    """
     try:
-        # Get ODP organisations
-        odp_orgs = get_odp_organisations()
+        all_resources_to_retire = []
+        all_retired_lpas = set()
 
-        # Get CA endpoints in ODP
-        endpoints_in_odp = get_ca_endpoints_in_odp(odp_orgs)
+        # Process conservation-area dataset
+        print("\n" + "="*60)
+        print("RETIRING CONSERVATION-AREA ENDPOINTS")
+        print("="*60)
+        ca_endpoints, ca_retired_lpas = get_endpoints_by_dataset('conservation-area')
+        all_retired_lpas.update(ca_retired_lpas)
+        if len(ca_endpoints) > 0:
+            update_endpoint_dates(ca_endpoints)
+            ca_resources = get_resources_for_retirement(ca_endpoints)
+            all_resources_to_retire.extend(ca_resources)
+            print(f"Conservation-area: {len(ca_endpoints)} endpoints, {len(ca_resources)} resources")
+        else:
+            print("Conservation-area: No endpoints to retire")
 
-        if len(endpoints_in_odp) == 0:
-            print("No endpoints to retire. Exiting.")
-            return
+        # Process conservation-area-document dataset
+        print("\n" + "="*60)
+        print("RETIRING CONSERVATION-AREA-DOCUMENT ENDPOINTS")
+        print("="*60)
+        cad_endpoints, cad_retired_lpas = get_endpoints_by_dataset('conservation-area-document')
+        all_retired_lpas.update(cad_retired_lpas)
+        if len(cad_endpoints) > 0:
+            update_endpoint_dates(cad_endpoints)
+            cad_resources = get_resources_for_retirement(cad_endpoints)
+            all_resources_to_retire.extend(cad_resources)
+            print(f"Conservation-area-document: {len(cad_endpoints)} endpoints, {len(cad_resources)} resources")
+        else:
+            print("Conservation-area-document: No endpoints to retire")
 
-        # Update endpoint and source records
-        update_endpoint_dates(endpoints_in_odp)
+        # Update old-resource.csv with all collected resources
+        if len(all_resources_to_retire) > 0:
+            print("\n" + "="*60)
+            print("UPDATING OLD-RESOURCE CSV")
+            print("="*60)
+            update_old_resource_csv(all_resources_to_retire)
 
-        # Get resources and update old-resource.csv
-        resources_to_retire = get_resources_for_retirement(endpoints_in_odp)
-        if len(resources_to_retire) > 0:
-            update_old_resource_csv(resources_to_retire)
+        # Final check: report how many retired LPAs are in ODP
+        if len(all_retired_lpas) > 0:
+            print("\n" + "="*60)
+            print("ODP COVERAGE CHECK")
+            print("="*60)
+            ca_odp_orgs = get_odp_organisations_for_dataset('conservation-area')
+            cad_odp_orgs = get_odp_organisations_for_dataset('conservation-area-document')
+            all_odp_orgs = ca_odp_orgs | cad_odp_orgs
 
-        print("\nRetirement complete!")
+            retired_in_odp = 0
+            for lpa in all_retired_lpas:
+                if f'local-authority:{lpa}' in all_odp_orgs:
+                    retired_in_odp += 1
+
+            print(f"LPAs where MHCLG data was retired: {len(all_retired_lpas)}")
+            print(f"  Of these, in ODP: {retired_in_odp}")
+            print(f"  Of these, NOT in ODP: {len(all_retired_lpas) - retired_in_odp}")
+
+        print("\n" + "="*60)
+        print("RETIREMENT COMPLETE!")
+        print("="*60)
     except Exception as e:
         print(f"Error: {e}")
         raise


### PR DESCRIPTION
## Data Template

**Ticket**
- Link: https://github.com/orgs/digital-land/projects/15?pane=issue&itemId=158787024&issue=digital-land%7Cconfig%7C2212

**Type**
- [ ] New data
- [X] Data monitoring
- [ ] Data fix

**Data updated (list organisation and dataset):**
- Dataset:

**Expected outcome (if relevant):**
- [ ] New endpoint & source
- [ ] New lookups
- [ ] Extra endpoint config (e.g. column, concat)
- [ ] Retired old endpoint & source
- [ ] Retired old entities
- [ ] Retired old resource

**Additional information:**
This PR is correcting the retire-mhclg-ca-data.py to correctly identify MHCLG seeded data in the CA/CAD datasets that need retiring once authoritative data is sourced. 

The changes in the CSVs that are outputted from running the code have been manually checked between myself and Swati.

**Requester's checklist:**
- [ ] Have checked if any old endpoints to retire
- [ ] Have validated endpoint (with check or endpoint checker)
- [ ] Have checked expected number of lookups
- [ ] Have checked for any geo duplicates (if CA data)
- [ ] Have updated entity-organisation.csv (if CA data)

**Reviewer's checklist:**
- [ ] Expected checks have been completed by PR requester
- [ ] Correct date format used in config files (YYYY-mm-dd)
- [ ] Number of new lookups is as expected from source data
- [ ] Spot checked that newly assigned entity numbers aren’t in use
