### PR TITLE
Update the 'old-entity and entity have no shared values' test

### DIFF
--- a/tests/acceptance/test_config_dataset.py
+++ b/tests/acceptance/test_config_dataset.py
@@ -114,8 +114,8 @@ def _check_old_entity_shared_values_with_status(file_path):
         if not is_allowed:
             conflicts.append({
                 "shared_id": shared_id,
-                "old_entity_lines": old_entities_dict[shared_id],
-                "entity_target_lines": entity_targets_dict[shared_id],
+                "old_entity_rows": old_entities_dict[shared_id],
+                "entity_target_rows": entity_targets_dict[shared_id],
             })
 
     if conflicts:
@@ -123,8 +123,8 @@ def _check_old_entity_shared_values_with_status(file_path):
         for conflict in conflicts:
             details.append(
                 f"  - Entity '{conflict['shared_id']}' appears in both columns "
-                f"(old-entity lines {conflict['old_entity_lines']}, "
-                f"entity lines {conflict['entity_target_lines']})"
+                f"(old-entity row {conflict['old_entity_rows']}, "
+                f"entity row {conflict['entity_target_rows']})"
             )
         pytest.fail(
             f"Conflicting shared entities across 'old-entity' and 'entity' columns in {file_path}:\n" + "\n".join(details)


### PR DESCRIPTION
## Data Template

**Ticket**
- Link: Work has been created adhoc to respond to tests failing in this PR: https://github.com/digital-land/config/pull/2431/changes/3aee35c9f046ea2916d54080809a3d89fc363773

**Type**
- [ ] New data
- [X] Data monitoring
- [ ] Data fix


**Additional information:**
Currently, the 'old-entity and entity have no shared values' test checks if an entity appears in both the entity and old-entity columns of old-entity.csv. 

This PR expands the test to:
- Identifies shared values between old-entity and entity columns
  - Allows them if the entity row has status "410" (retirement)
  - Allows them if the old-entity row has status "301" (redirect) pointing to that entity
- Fails only on truly conflicting cases

I've also updated the printed error so that the rows with the affected entities are clearly printed, e.g.:
<img width="942" height="142" alt="image" src="https://github.com/user-attachments/assets/4830883a-4859-4402-b2be-1dfddf8653d1" />

When I've run this locally, the previously broken entities 44013322 and 44013327 in this [PR](https://github.com/digital-land/config/pull/2431) passes.

**Requester's checklist:**
- [ ] Have checked if any old endpoints to retire
- [ ] Have validated endpoint (with check or endpoint checker)
- [ ] Have checked expected number of lookups
- [ ] Have checked for any geo duplicates (if CA data)
- [ ] Have updated entity-organisation.csv (if CA data)

**Reviewer's checklist:**
- [ ] Expected checks have been completed by PR requester
- [ ] Correct date format used in config files (YYYY-mm-dd)
- [ ] Number of new lookups is as expected from source data
- [ ] Spot checked that newly assigned entity numbers aren’t in use
