### PR TITLE
add data comand update pipelines column in source csv

### DIFF
--- a/bin/add_data.py
+++ b/bin/add_data.py
@@ -254,7 +254,24 @@ def append_source(response: dict, collection: str) -> None:
     source_summary = response.get("response", {}).get("data", {}).get("source-summary", {})
 
     if as_bool(source_summary.get("documentation_url_in_source_csv")):
-        print("Source already exists in source.csv, skipping")
+        pipelines_append = source_summary.get("pipelines_append_required") or {}
+        updated = pipelines_append.get("updated", "").strip()
+        if updated:
+            existing_entry = source_summary.get("existing_source_entry") or {}
+            source_hash = existing_entry.get("source", "").strip()
+            if not source_hash:
+                print("pipelines_append_required present but no source hash in existing_source_entry, skipping")
+                return
+            frame = pd.read_csv(source_file, dtype=str, keep_default_na=False)
+            mask = frame["source"] == source_hash
+            if not mask.any():
+                print(f"Source {source_hash} not found in source.csv, skipping pipelines update")
+                return
+            frame.loc[mask, "pipelines"] = updated
+            frame.to_csv(source_file, index=False, lineterminator="\r\n")
+            print(f"Updated pipelines to '{updated}' for source {source_hash} in source.csv")
+        else:
+            print("Source already exists in source.csv, skipping")
         return
 
     new_entry = source_summary.get("new_source_entry")


### PR DESCRIPTION
## Description

Problem: When a single endpoint serves multiple datasets, the source row already exists in source.csv (same hash), so documentation_url_in_source_csv is true. Previously the function just skipped — but the pipelines column for that row needed updating to include the new dataset.

Fix: When documentation_url_in_source_csv is true, check for pipelines_append_required.updated in the response. If present, load source.csv, find the row by source hash (from existing_source_entry.source), overwrite the pipelines column with the updated value, and write the file back. If pipelines_append_required is absent, the old skip behaviour is unchanged.

**Ticket**
- Link: https://github.com/orgs/digital-land/projects/15/views/1?pane=issue&itemId=182646473&issue=digital-land%7Cconfig-manager%7C153
