### PR TITLE
Retire fake MHCLG data in local plans and plan timetables

### DIFF
--- a/.github/scripts/retire-mhclg-plan-data.py
+++ b/.github/scripts/retire-mhclg-plan-data.py
@@ -182,7 +182,7 @@ def retire_plan_timetable_data(lookup_rows, entity_org_rows):
     return entities_to_retire
 
 
-def retire_local_plan_data(lookup_rows):
+def retire_local_plan_data(lookup_rows, entity_org_rows):
     """Retire MHCLG seeded data for local-plan dataset. Returns set of entities."""
     logger.info("\n=== Processing local-plan dataset ===")
 
@@ -216,15 +216,20 @@ def retire_local_plan_data(lookup_rows):
     org_mapping = load_organisation_mapping()
     lpa_orgs = set(r['organisation'] for r in lpa_rows)
 
-    fake_plan_references = set()
+    # Validation #4: Fail if any LPA org name could not be resolved
+    unresolved_orgs = [org for org in lpa_orgs if org not in org_mapping]
+    if unresolved_orgs:
+        raise ValueError(
+            f"ERROR: Could not resolve organisation names for: {', '.join(unresolved_orgs)}. "
+            "Cannot generate fake plan references without names."
+        )
+
+    fake_plan_references = {}
     for org in lpa_orgs:
-        if org in org_mapping:
-            slug = authority_to_slug(org_mapping[org])
-            reference = f"{slug}-new-local-plan"
-            fake_plan_references.add(reference)
-            logger.info(f"  {org}: {reference}")
-        else:
-            logger.warning(f"  WARNING: Could not find name for {org}")
+        slug = authority_to_slug(org_mapping[org])
+        reference = f"{slug}-new-local-plan"
+        fake_plan_references[org] = reference
+        logger.info(f"  {org}: {reference}")
 
     logger.info(f"Generated {len(fake_plan_references)} fake plan references")
 
@@ -233,7 +238,7 @@ def retire_local_plan_data(lookup_rows):
     for row in lookup_rows:
         if (row['organisation'] == MHCLG_ORG
                 and row['prefix'] == prefix
-                and row['reference'] in fake_plan_references):
+                and row['reference'] in fake_plan_references.values()):
             entity = int(row['entity'])
             if entity > threshold:
                 raise ValueError(
@@ -243,6 +248,48 @@ def retire_local_plan_data(lookup_rows):
             mhclg_entities.add(entity)
 
     logger.info(f"Found {len(mhclg_entities)} MHCLG local plan entities to retire")
+
+    # Validation #3: Cross-check each entity falls within an entity-organisation range for its LPA
+    entity_org_ranges = [
+        (r['organisation'], int(r['entity-minimum']), int(r['entity-maximum']))
+        for r in entity_org_rows
+        if r['dataset'] == prefix
+    ]
+
+    for entity in mhclg_entities:
+        # Find which LPA this entity's reference belongs to
+        reference = None
+        for row in lookup_rows:
+            if (row['prefix'] == prefix
+                    and int(row['entity']) == entity
+                    and row['organisation'] == MHCLG_ORG):
+                reference = row['reference']
+                break
+
+        # Find the LPA org that generated this reference
+        lpa_org = None
+        for org, ref in fake_plan_references.items():
+            if ref == reference:
+                lpa_org = org
+                break
+
+        if not lpa_org:
+            raise ValueError(
+                f"ERROR: Entity {entity} (ref={reference}) does not map back to any LPA organisation."
+            )
+
+        # Verify entity falls within an entity-organisation range for this LPA
+        in_range = any(
+            org == lpa_org and emin <= entity <= emax
+            for org, emin, emax in entity_org_ranges
+        )
+        if not in_range:
+            raise ValueError(
+                f"ERROR: Entity {entity} (ref={reference}) does not fall within any "
+                f"entity-organisation range for {lpa_org}."
+            )
+
+    logger.info(f"✓ All entities cross-checked against entity-organisation.csv")
     logger.info(f"✓ Queued {len(mhclg_entities)} local-plan entities for retirement")
     return mhclg_entities
 
@@ -306,7 +353,7 @@ def main():
     logger.info(f"Loaded old-entity.csv ({len(old_entity_rows)} rows)")
 
     timetable_entities = retire_plan_timetable_data(lookup_rows, entity_org_rows)
-    local_plan_entities = retire_local_plan_data(lookup_rows)
+    local_plan_entities = retire_local_plan_data(lookup_rows, entity_org_rows)
 
     all_entities = timetable_entities | local_plan_entities
 

--- a/.github/scripts/retire-mhclg-plan-data.py
+++ b/.github/scripts/retire-mhclg-plan-data.py
@@ -37,10 +37,10 @@ OLD_ENTITY_PATH = PIPELINE_DIR / 'old-entity.csv'
 
 MHCLG_ORG = 'government-organisation:D1342'
 
-# Threshold entity numbers: MHCLG fake template data ends at these values
-MHCLG_THRESHOLDS = {
-    'plan-timetable': 5109686,
-    'local-plan': 4220966,
+# Entity ranges for MHCLG fake template data
+MHCLG_RANGES = {
+    'plan-timetable': (5101702, 5109686),
+    'local-plan': (4220656, 4220966),
 }
 
 # Entity range for MHCLG seeded plan-timetable data (inclusive difference = 22, count = 23)
@@ -87,7 +87,7 @@ def retire_plan_timetable_data(lookup_rows, entity_org_rows):
     """Retire MHCLG seeded data for plan-timetable dataset. Returns set of entities."""
     logger.info("\n=== Processing plan-timetable dataset ===")
 
-    threshold = MHCLG_THRESHOLDS['plan-timetable']
+    mhclg_range_min, mhclg_range_max = MHCLG_RANGES['plan-timetable']
     prefix = 'plan-timetable'
 
     # Step 1: Find LPAs that provided data
@@ -100,13 +100,16 @@ def retire_plan_timetable_data(lookup_rows, entity_org_rows):
         logger.warning(f"No LPA data found for {prefix}")
         return set()
 
-    # Separate LPAs that created new data (above threshold) from those that
-    # updated MHCLG data in-place (below threshold). In-place updates don't
+    # Separate LPAs that created new data (outside MHCLG range) from those that
+    # updated MHCLG data in-place (within MHCLG range). In-place updates don't
     # need retirement since the MHCLG data was overwritten, not duplicated.
-    lpa_rows = [r for r in all_lpa_rows if int(r['entity']) > threshold]
+    def is_in_mhclg_range(entity):
+        return mhclg_range_min <= entity <= mhclg_range_max
+
+    lpa_rows = [r for r in all_lpa_rows if not is_in_mhclg_range(int(r['entity']))]
 
     updated_in_place_orgs = set(
-        r['organisation'] for r in all_lpa_rows if int(r['entity']) <= threshold
+        r['organisation'] for r in all_lpa_rows if is_in_mhclg_range(int(r['entity']))
     ) - set(r['organisation'] for r in lpa_rows)
 
     if updated_in_place_orgs:
@@ -116,13 +119,13 @@ def retire_plan_timetable_data(lookup_rows, entity_org_rows):
         )
 
     if not lpa_rows:
-        logger.info("No LPAs with new data above threshold — nothing to retire")
+        logger.info("No LPAs with new data outside MHCLG range — nothing to retire")
         return set()
 
     min_lpa = min(int(r['entity']) for r in lpa_rows)
     max_lpa = max(int(r['entity']) for r in lpa_rows)
     logger.info(f"LPA entity range: {min_lpa} - {max_lpa}")
-    logger.info(f"✓ All LPA entities > {threshold}")
+    logger.info(f"✓ All LPA entities outside MHCLG range ({mhclg_range_min}-{mhclg_range_max})")
 
     # Step 2: Get min/max entity per organisation from LPA data
     org_ranges = {}
@@ -217,7 +220,7 @@ def retire_local_plan_data(lookup_rows, entity_org_rows):
     """Retire MHCLG seeded data for local-plan dataset. Returns set of entities."""
     logger.info("\n=== Processing local-plan dataset ===")
 
-    threshold = MHCLG_THRESHOLDS['local-plan']
+    mhclg_range_min, mhclg_range_max = MHCLG_RANGES['local-plan']
     prefix = 'local-plan'
 
     # Step 1: Find LPAs that provided data
@@ -230,13 +233,16 @@ def retire_local_plan_data(lookup_rows, entity_org_rows):
         logger.warning(f"No LPA data found for {prefix}")
         return set()
 
-    # Separate LPAs that created new data (above threshold) from those that
-    # updated MHCLG data in-place (below threshold). In-place updates don't
+    # Separate LPAs that created new data (outside MHCLG range) from those that
+    # updated MHCLG data in-place (within MHCLG range). In-place updates don't
     # need retirement since the MHCLG data was overwritten, not duplicated.
-    lpa_rows = [r for r in all_lpa_rows if int(r['entity']) > threshold]
+    def is_in_mhclg_range(entity):
+        return mhclg_range_min <= entity <= mhclg_range_max
+
+    lpa_rows = [r for r in all_lpa_rows if not is_in_mhclg_range(int(r['entity']))]
 
     updated_in_place_orgs = set(
-        r['organisation'] for r in all_lpa_rows if int(r['entity']) <= threshold
+        r['organisation'] for r in all_lpa_rows if is_in_mhclg_range(int(r['entity']))
     ) - set(r['organisation'] for r in lpa_rows)
 
     if updated_in_place_orgs:
@@ -246,13 +252,13 @@ def retire_local_plan_data(lookup_rows, entity_org_rows):
         )
 
     if not lpa_rows:
-        logger.info("No LPAs with new data above threshold — nothing to retire")
+        logger.info("No LPAs with new data outside MHCLG range — nothing to retire")
         return set()
 
     min_lpa = min(int(r['entity']) for r in lpa_rows)
     max_lpa = max(int(r['entity']) for r in lpa_rows)
     logger.info(f"LPA entity range: {min_lpa} - {max_lpa}")
-    logger.info(f"✓ All LPA entities > {threshold}")
+    logger.info(f"✓ All LPA entities outside MHCLG range ({mhclg_range_min}-{mhclg_range_max})")
 
     # Step 2: Load organisation mapping to generate fake plan references
     org_mapping = load_organisation_mapping()
@@ -282,10 +288,10 @@ def retire_local_plan_data(lookup_rows, entity_org_rows):
                 and row['prefix'] == prefix
                 and row['reference'] in fake_plan_references.values()):
             entity = int(row['entity'])
-            if entity > threshold:
+            if not is_in_mhclg_range(entity):
                 raise ValueError(
-                    f"ERROR: Found MHCLG entity {entity} above threshold {threshold}. "
-                    "This indicates data corruption."
+                    f"ERROR: Found MHCLG entity {entity} outside expected range "
+                    f"({mhclg_range_min}-{mhclg_range_max}). This indicates data corruption."
                 )
             mhclg_entities.add(entity)
 

--- a/.github/scripts/retire-mhclg-plan-data.py
+++ b/.github/scripts/retire-mhclg-plan-data.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""
+Retire fake MHCLG template data for local plans and plan timetables.
+
+When LPAs provide their own data, this script removes the pre-seeded MHCLG data
+that was added as placeholders. MHCLG seeded data is identified by:
+- Entity ranges of 23 entities (difference of 22) for plan timetables
+- Reference matching {slug}-new-local-plan for local plans
+
+Each retired entity is added to old-entity.csv with status 410 and today's date.
+
+Datasets processed:
+- local-plan
+- plan-timetable
+"""
+
+import csv
+import io
+import urllib.request
+import sys
+import logging
+from datetime import date
+from pathlib import Path
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s: %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+PIPELINE_DIR = REPO_ROOT / 'pipeline' / 'local-plan'
+LOOKUP_PATH = PIPELINE_DIR / 'lookup.csv'
+ENTITY_ORG_PATH = PIPELINE_DIR / 'entity-organisation.csv'
+OLD_ENTITY_PATH = PIPELINE_DIR / 'old-entity.csv'
+
+MHCLG_ORG = 'government-organisation:D1342'
+
+# Threshold entity numbers: MHCLG fake template data ends at these values
+MHCLG_THRESHOLDS = {
+    'plan-timetable': 5109686,
+    'local-plan': 4220966,
+}
+
+# Entity range for MHCLG seeded plan-timetable data (inclusive difference = 22, count = 23)
+MHCLG_ENTITY_RANGE = 22
+
+
+def read_csv_file(path):
+    """Read a CSV file and return a list of dicts."""
+    with open(path, 'r', encoding='utf-8') as f:
+        return list(csv.DictReader(f))
+
+
+def authority_to_slug(name):
+    """Convert authority name to slug format."""
+    if not name:
+        return ''
+    slug = name.lower().strip()
+    slug = slug.replace('&', 'and')
+    slug = slug.replace('–', '-').replace('—', '-').replace('/', '-')
+    slug = slug.replace(' ', '-')
+    slug = ''.join(c for c in slug if c.isalnum() or c == '-')
+    while '--' in slug:
+        slug = slug.replace('--', '-')
+    return slug.strip('-')
+
+
+def load_organisation_mapping():
+    """Load mapping from organisation CURIE codes to names."""
+    logger.info("Loading organisation mapping from planning.data.gov.uk...")
+    url = 'https://files.planning.data.gov.uk/organisation-collection/dataset/organisation.csv'
+    with urllib.request.urlopen(url) as response:
+        content = response.read().decode('utf-8')
+
+    reader = csv.DictReader(io.StringIO(content))
+    mapping = {}
+    for row in reader:
+        mapping[row['organisation']] = row['name']
+
+    logger.info(f"Loaded {len(mapping)} organisations")
+    return mapping
+
+
+def retire_plan_timetable_data(lookup_rows, entity_org_rows):
+    """Retire MHCLG seeded data for plan-timetable dataset. Returns set of entities."""
+    logger.info("\n=== Processing plan-timetable dataset ===")
+
+    threshold = MHCLG_THRESHOLDS['plan-timetable']
+    prefix = 'plan-timetable'
+
+    # Step 1: Find LPAs that provided data
+    lpa_rows = [
+        r for r in lookup_rows
+        if r['organisation'] != MHCLG_ORG and r['prefix'] == prefix
+    ]
+
+    if not lpa_rows:
+        logger.warning(f"No LPA data found for {prefix}")
+        return set()
+
+    # Validate: all LPA entities should be above threshold
+    lpa_entities = [int(r['entity']) for r in lpa_rows]
+    min_lpa = min(lpa_entities)
+    max_lpa = max(lpa_entities)
+    logger.info(f"LPA entity range: {min_lpa} - {max_lpa}")
+
+    if min_lpa <= threshold:
+        raise ValueError(
+            f"ERROR: Some LPA entities are not above threshold ({threshold}). "
+            f"Found {min_lpa}. This indicates corrupted or invalid data."
+        )
+    logger.info(f"✓ All LPA entities > {threshold}")
+
+    # Step 2: Get min/max entity per organisation from LPA data
+    org_ranges = {}
+    for row in lpa_rows:
+        org = row['organisation']
+        entity = int(row['entity'])
+        if org not in org_ranges:
+            org_ranges[org] = {'min': entity, 'max': entity}
+        else:
+            org_ranges[org]['min'] = min(org_ranges[org]['min'], entity)
+            org_ranges[org]['max'] = max(org_ranges[org]['max'], entity)
+
+    logger.info(f"Found {len(org_ranges)} LPAs with authoritative data")
+
+    # Step 3: Filter entity-organisation to this dataset and orgs with data
+    entity_org_filtered = [
+        r for r in entity_org_rows
+        if r['dataset'] == prefix and r['organisation'] in org_ranges
+    ]
+
+    # Step 4: Anti-join - find ranges NOT matching the LPA's authoritative data
+    lpa_range_keys = {
+        (org, data['min'], data['max'])
+        for org, data in org_ranges.items()
+    }
+
+    mhclg_to_retire = []
+    for row in entity_org_filtered:
+        org = row['organisation']
+        entity_min = int(row['entity-minimum'])
+        entity_max = int(row['entity-maximum'])
+        if (org, entity_min, entity_max) not in lpa_range_keys:
+            mhclg_to_retire.append((org, entity_min, entity_max))
+
+    # Step 5: Filter to ranges with exactly 23 entities (MHCLG template size)
+    mhclg_to_retire = [
+        (org, emin, emax) for org, emin, emax in mhclg_to_retire
+        if (emax - emin) == MHCLG_ENTITY_RANGE
+    ]
+    logger.info(f"Found {len(mhclg_to_retire)} MHCLG-seeded entity ranges to retire")
+
+    if not mhclg_to_retire:
+        logger.warning("No MHCLG entity ranges to retire for plan-timetable")
+        return set()
+
+    # Step 6: Expand ranges to individual entities and verify they are MHCLG
+    entities_to_retire = set()
+
+    for org, entity_min, entity_max in mhclg_to_retire:
+        mhclg_entities = [
+            int(r['entity']) for r in lookup_rows
+            if r['organisation'] == MHCLG_ORG
+            and r['prefix'] == prefix
+            and int(r['entity']) >= entity_min
+            and int(r['entity']) <= entity_max
+        ]
+
+        expected_count = entity_max - entity_min + 1
+        if len(mhclg_entities) != expected_count:
+            logger.warning(
+                f"  {org}: Expected {expected_count} entities in range "
+                f"[{entity_min}, {entity_max}], found {len(mhclg_entities)}"
+            )
+
+        entities_to_retire.update(mhclg_entities)
+
+    logger.info(f"✓ Verified and queued {len(entities_to_retire)} plan-timetable entities for retirement")
+    return entities_to_retire
+
+
+def retire_local_plan_data(lookup_rows):
+    """Retire MHCLG seeded data for local-plan dataset. Returns set of entities."""
+    logger.info("\n=== Processing local-plan dataset ===")
+
+    threshold = MHCLG_THRESHOLDS['local-plan']
+    prefix = 'local-plan'
+
+    # Step 1: Find LPAs that provided data
+    lpa_rows = [
+        r for r in lookup_rows
+        if r['organisation'] != MHCLG_ORG and r['prefix'] == prefix
+    ]
+
+    if not lpa_rows:
+        logger.warning(f"No LPA data found for {prefix}")
+        return set()
+
+    # Validate: all LPA entities should be above threshold
+    lpa_entities = [int(r['entity']) for r in lpa_rows]
+    min_lpa = min(lpa_entities)
+    max_lpa = max(lpa_entities)
+    logger.info(f"LPA entity range: {min_lpa} - {max_lpa}")
+
+    if min_lpa <= threshold:
+        raise ValueError(
+            f"ERROR: Some LPA entities are not above threshold ({threshold}). "
+            f"Found {min_lpa}. This indicates corrupted or invalid data."
+        )
+    logger.info(f"✓ All LPA entities > {threshold}")
+
+    # Step 2: Load organisation mapping to generate fake plan references
+    org_mapping = load_organisation_mapping()
+    lpa_orgs = set(r['organisation'] for r in lpa_rows)
+
+    fake_plan_references = set()
+    for org in lpa_orgs:
+        if org in org_mapping:
+            slug = authority_to_slug(org_mapping[org])
+            reference = f"{slug}-new-local-plan"
+            fake_plan_references.add(reference)
+            logger.info(f"  {org}: {reference}")
+        else:
+            logger.warning(f"  WARNING: Could not find name for {org}")
+
+    logger.info(f"Generated {len(fake_plan_references)} fake plan references")
+
+    # Step 3: Find MHCLG entities that match these fake plan references
+    mhclg_entities = set()
+    for row in lookup_rows:
+        if (row['organisation'] == MHCLG_ORG
+                and row['prefix'] == prefix
+                and row['reference'] in fake_plan_references):
+            entity = int(row['entity'])
+            if entity > threshold:
+                raise ValueError(
+                    f"ERROR: Found MHCLG entity {entity} above threshold {threshold}. "
+                    "This indicates data corruption."
+                )
+            mhclg_entities.add(entity)
+
+    logger.info(f"Found {len(mhclg_entities)} MHCLG local plan entities to retire")
+    logger.info(f"✓ Queued {len(mhclg_entities)} local-plan entities for retirement")
+    return mhclg_entities
+
+
+def save_retired_entities(entities_to_retire, old_entity_rows):
+    """Append retired entities to old-entity.csv."""
+    logger.info(f"\n=== Saving {len(entities_to_retire)} entities to old-entity.csv ===")
+
+    if not entities_to_retire:
+        logger.warning("No entities to retire")
+        return
+
+    # Check for duplicates (entities already retired)
+    existing = set(int(r['old-entity']) for r in old_entity_rows)
+    duplicates = entities_to_retire & existing
+
+    if duplicates:
+        logger.warning(f"⚠ {len(duplicates)} entities are already in old-entity.csv (skipping)")
+        entities_to_add = entities_to_retire - duplicates
+    else:
+        entities_to_add = entities_to_retire
+
+    if not entities_to_add:
+        logger.info("No new entities to add")
+        return
+
+    # Read existing file content and append new rows
+    fieldnames = ['old-entity', 'status', 'entity', 'notes', 'end-date', 'entry-date', 'start-date']
+
+    with open(OLD_ENTITY_PATH, 'a', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        for entity_id in sorted(entities_to_add):
+            writer.writerow({
+                'old-entity': entity_id,
+                'status': 410,
+                'entity': '',
+                'notes': 'Retiring fake MHCLG template data',
+                'end-date': '',
+                'entry-date': date.today().isoformat(),
+                'start-date': '',
+            })
+
+    logger.info(f"✓ Added {len(entities_to_add)} rows to old-entity.csv")
+    logger.info(f"  Total old-entity entries: {len(old_entity_rows) + len(entities_to_add)}")
+
+
+def main():
+    """Main entry point."""
+    # Validate files exist
+    for path in [LOOKUP_PATH, ENTITY_ORG_PATH, OLD_ENTITY_PATH]:
+        if not path.exists():
+            logger.error(f"Required file not found: {path}")
+            sys.exit(1)
+
+    logger.info("Loading CSV files...")
+    lookup_rows = read_csv_file(LOOKUP_PATH)
+    entity_org_rows = read_csv_file(ENTITY_ORG_PATH)
+    old_entity_rows = read_csv_file(OLD_ENTITY_PATH)
+    logger.info(f"Loaded lookup.csv ({len(lookup_rows)} rows)")
+    logger.info(f"Loaded entity-organisation.csv ({len(entity_org_rows)} rows)")
+    logger.info(f"Loaded old-entity.csv ({len(old_entity_rows)} rows)")
+
+    timetable_entities = retire_plan_timetable_data(lookup_rows, entity_org_rows)
+    local_plan_entities = retire_local_plan_data(lookup_rows)
+
+    all_entities = timetable_entities | local_plan_entities
+
+    logger.info(f"\n=== Summary ===")
+    logger.info(f"plan-timetable: {len(timetable_entities)} entities")
+    logger.info(f"local-plan: {len(local_plan_entities)} entities")
+    logger.info(f"Total: {len(all_entities)} entities")
+
+    if not all_entities:
+        logger.warning("No entities to retire")
+        sys.exit(0)
+
+    save_retired_entities(all_entities, old_entity_rows)
+    logger.info("\n✓ Retirement completed successfully")
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/scripts/retire-mhclg-plan-data.py
+++ b/.github/scripts/retire-mhclg-plan-data.py
@@ -91,26 +91,37 @@ def retire_plan_timetable_data(lookup_rows, entity_org_rows):
     prefix = 'plan-timetable'
 
     # Step 1: Find LPAs that provided data
-    lpa_rows = [
+    all_lpa_rows = [
         r for r in lookup_rows
         if r['organisation'] != MHCLG_ORG and r['prefix'] == prefix
     ]
 
-    if not lpa_rows:
+    if not all_lpa_rows:
         logger.warning(f"No LPA data found for {prefix}")
         return set()
 
-    # Validate: all LPA entities should be above threshold
-    lpa_entities = [int(r['entity']) for r in lpa_rows]
-    min_lpa = min(lpa_entities)
-    max_lpa = max(lpa_entities)
-    logger.info(f"LPA entity range: {min_lpa} - {max_lpa}")
+    # Separate LPAs that created new data (above threshold) from those that
+    # updated MHCLG data in-place (below threshold). In-place updates don't
+    # need retirement since the MHCLG data was overwritten, not duplicated.
+    lpa_rows = [r for r in all_lpa_rows if int(r['entity']) > threshold]
 
-    if min_lpa <= threshold:
-        raise ValueError(
-            f"ERROR: Some LPA entities are not above threshold ({threshold}). "
-            f"Found {min_lpa}. This indicates corrupted or invalid data."
+    updated_in_place_orgs = set(
+        r['organisation'] for r in all_lpa_rows if int(r['entity']) <= threshold
+    ) - set(r['organisation'] for r in lpa_rows)
+
+    if updated_in_place_orgs:
+        logger.info(
+            f"Skipping {len(updated_in_place_orgs)} LPAs that updated MHCLG data in-place "
+            f"(no retirement needed): {', '.join(sorted(updated_in_place_orgs))}"
         )
+
+    if not lpa_rows:
+        logger.info("No LPAs with new data above threshold — nothing to retire")
+        return set()
+
+    min_lpa = min(int(r['entity']) for r in lpa_rows)
+    max_lpa = max(int(r['entity']) for r in lpa_rows)
+    logger.info(f"LPA entity range: {min_lpa} - {max_lpa}")
     logger.info(f"✓ All LPA entities > {threshold}")
 
     # Step 2: Get min/max entity per organisation from LPA data
@@ -124,7 +135,7 @@ def retire_plan_timetable_data(lookup_rows, entity_org_rows):
             org_ranges[org]['min'] = min(org_ranges[org]['min'], entity)
             org_ranges[org]['max'] = max(org_ranges[org]['max'], entity)
 
-    logger.info(f"Found {len(org_ranges)} LPAs with authoritative data")
+    logger.info(f"Found {len(org_ranges)} LPAs with new authoritative data")
 
     # Step 3: Filter entity-organisation to this dataset and orgs with data
     entity_org_filtered = [
@@ -153,8 +164,18 @@ def retire_plan_timetable_data(lookup_rows, entity_org_rows):
     ]
     logger.info(f"Found {len(mhclg_to_retire)} MHCLG-seeded entity ranges to retire")
 
+    # Completeness check: every LPA with data should have a MHCLG template range
+    orgs_with_retirement = set(org for org, _, _ in mhclg_to_retire)
+    orgs_missing = set(org_ranges.keys()) - orgs_with_retirement
+    if orgs_missing:
+        raise ValueError(
+            f"ERROR: No MHCLG template range found for: {', '.join(sorted(orgs_missing))}. "
+            "These LPAs provided data but no fake template was identified to retire."
+        )
+    logger.info(f"✓ All {len(org_ranges)} LPAs have a matching MHCLG template range")
+
     if not mhclg_to_retire:
-        logger.warning("No MHCLG entity ranges to retire for plan-timetable")
+        logger.info("No MHCLG entity ranges to retire for plan-timetable")
         return set()
 
     # Step 6: Expand ranges to individual entities and verify they are MHCLG
@@ -178,6 +199,16 @@ def retire_plan_timetable_data(lookup_rows, entity_org_rows):
 
         entities_to_retire.update(mhclg_entities)
 
+    # No-overlap check: ensure no entity being retired is also LPA authoritative data
+    lpa_entity_set = set(int(r['entity']) for r in lpa_rows)
+    overlap = entities_to_retire & lpa_entity_set
+    if overlap:
+        raise ValueError(
+            f"ERROR: Entities {sorted(overlap)} are in BOTH the retirement list and "
+            "LPA authoritative data. Aborting to prevent data loss."
+        )
+    logger.info(f"✓ No overlap with LPA authoritative data")
+
     logger.info(f"✓ Verified and queued {len(entities_to_retire)} plan-timetable entities for retirement")
     return entities_to_retire
 
@@ -190,26 +221,37 @@ def retire_local_plan_data(lookup_rows, entity_org_rows):
     prefix = 'local-plan'
 
     # Step 1: Find LPAs that provided data
-    lpa_rows = [
+    all_lpa_rows = [
         r for r in lookup_rows
         if r['organisation'] != MHCLG_ORG and r['prefix'] == prefix
     ]
 
-    if not lpa_rows:
+    if not all_lpa_rows:
         logger.warning(f"No LPA data found for {prefix}")
         return set()
 
-    # Validate: all LPA entities should be above threshold
-    lpa_entities = [int(r['entity']) for r in lpa_rows]
-    min_lpa = min(lpa_entities)
-    max_lpa = max(lpa_entities)
-    logger.info(f"LPA entity range: {min_lpa} - {max_lpa}")
+    # Separate LPAs that created new data (above threshold) from those that
+    # updated MHCLG data in-place (below threshold). In-place updates don't
+    # need retirement since the MHCLG data was overwritten, not duplicated.
+    lpa_rows = [r for r in all_lpa_rows if int(r['entity']) > threshold]
 
-    if min_lpa <= threshold:
-        raise ValueError(
-            f"ERROR: Some LPA entities are not above threshold ({threshold}). "
-            f"Found {min_lpa}. This indicates corrupted or invalid data."
+    updated_in_place_orgs = set(
+        r['organisation'] for r in all_lpa_rows if int(r['entity']) <= threshold
+    ) - set(r['organisation'] for r in lpa_rows)
+
+    if updated_in_place_orgs:
+        logger.info(
+            f"Skipping {len(updated_in_place_orgs)} LPAs that updated MHCLG data in-place "
+            f"(no retirement needed): {', '.join(sorted(updated_in_place_orgs))}"
         )
+
+    if not lpa_rows:
+        logger.info("No LPAs with new data above threshold — nothing to retire")
+        return set()
+
+    min_lpa = min(int(r['entity']) for r in lpa_rows)
+    max_lpa = max(int(r['entity']) for r in lpa_rows)
+    logger.info(f"LPA entity range: {min_lpa} - {max_lpa}")
     logger.info(f"✓ All LPA entities > {threshold}")
 
     # Step 2: Load organisation mapping to generate fake plan references
@@ -249,7 +291,36 @@ def retire_local_plan_data(lookup_rows, entity_org_rows):
 
     logger.info(f"Found {len(mhclg_entities)} MHCLG local plan entities to retire")
 
-    # Validation #3: Cross-check each entity falls within an entity-organisation range for its LPA
+    # Completeness check: every LPA with data should have a MHCLG template entity
+    orgs_with_retirement = set()
+    for row in lookup_rows:
+        if (row['organisation'] == MHCLG_ORG
+                and row['prefix'] == prefix
+                and row['reference'] in fake_plan_references.values()):
+            for org, ref in fake_plan_references.items():
+                if ref == row['reference']:
+                    orgs_with_retirement.add(org)
+                    break
+
+    orgs_missing = lpa_orgs - orgs_with_retirement
+    if orgs_missing:
+        raise ValueError(
+            f"ERROR: No MHCLG template entity found for: {', '.join(sorted(orgs_missing))}. "
+            "These LPAs provided data but no fake template was identified to retire."
+        )
+    logger.info(f"✓ All {len(lpa_orgs)} LPAs have a matching MHCLG template entity")
+
+    # No-overlap check: ensure no entity being retired is also LPA authoritative data
+    lpa_entity_set = set(int(r['entity']) for r in lpa_rows)
+    overlap = mhclg_entities & lpa_entity_set
+    if overlap:
+        raise ValueError(
+            f"ERROR: Entities {sorted(overlap)} are in BOTH the retirement list and "
+            "LPA authoritative data. Aborting to prevent data loss."
+        )
+    logger.info(f"✓ No overlap with LPA authoritative data")
+
+    # Cross-check each entity falls within an entity-organisation range for its LPA
     entity_org_ranges = [
         (r['organisation'], int(r['entity-minimum']), int(r['entity-maximum']))
         for r in entity_org_rows

--- a/.github/workflows/retire-mhclg-plan-data.yml
+++ b/.github/workflows/retire-mhclg-plan-data.yml
@@ -1,0 +1,95 @@
+name: Retire MHCLG Plan Data
+
+on:
+  workflow_dispatch:
+
+jobs:
+  retire-plan-data:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Run retire MHCLG plan data script
+        timeout-minutes: 10
+        run: |
+          echo "Starting retire MHCLG plan data script..."
+          python .github/scripts/retire-mhclg-plan-data.py
+          echo "Retire script completed"
+
+      - name: Commit and create PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          BRANCH_NAME="retire-mhclg-plan-data-$(date +%Y%m%d-%H%M)"
+
+          git config user.name "github-actions-bot"
+          git config user.email "noreply@github.com"
+
+          # Check if there are changes
+          if git diff --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          git checkout -b "$BRANCH_NAME"
+          git add pipeline/local-plan/old-entity.csv
+
+          # Double-check there are staged changes
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          git commit -m "Retire MHCLG plan data"
+
+          git push origin "$BRANCH_NAME"
+
+          # Create PR
+          gh pr create --title "Retire MHCLG plan data" \
+            --body "This PR contains automatic updates to retire MHCLG template data:
+
+          ## Changes
+
+          **Retire MHCLG Plan Template Data:**
+          - Identifies LPAs that have provided authoritative data
+          - Removes pre-seeded MHCLG template entities for those LPAs
+          - For plan-timetable: Retires 23-entity ranges (22 local plan events)
+          - For local-plan: Retires fake plan references (e.g., {slug}-new-local-plan)
+          - Adds retired entities to old-entity.csv with status 410
+
+          This PR was automatically created via the Retire MHCLG Plan Data workflow.
+
+          **Triggered by:** @${{ github.actor }}
+
+          Please review and merge if appropriate." \
+                                          --base main \
+                                          --head "$BRANCH_NAME"
+
+      - name: Summary
+        run: |
+          echo "### Retire MHCLG Plan Data" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Script executed:" >> $GITHUB_STEP_SUMMARY
+          echo "- Retire MHCLG plan data script" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Datasets processed:" >> $GITHUB_STEP_SUMMARY
+          echo "- local-plan" >> $GITHUB_STEP_SUMMARY
+          echo "- plan-timetable" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Check above for PR creation details." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Data Template

**Ticket**
- Link: https://github.com/orgs/digital-land/projects/15?pane=issue&itemId=182257637&issue=digital-land%7Cconfig%7C2565

**Type**
- [ ] New data
- [ ] Data monitoring
- [X] Data fix

**Data updated (list organisation and dataset):**
- Dataset: local-plan and plan-timetable

**Expected outcome (if relevant):**
- [ ] New endpoint & source
- [ ] New lookups
- [ ] Extra endpoint config (e.g. column, concat)
- [ ] Retired old endpoint & source
- [X] Retired old entities
- [ ] Retired old resource

**Additional information:**
When we created the local plans and plan timetable data, we were asked to create template data for every LPA. This was essentially fake data that LPAs could use to update with their emerging local plans.

This ticket:
- Purpose: Retires fake MHCLG template data from `old-entity.csv` (status 410) when an LPA provides their own authoritative data for plan-timetable or local-plan datasets
- Plan-timetable rule: If an LPA has entities above threshold 5109686, find their MHCLG entity range of exactly 23 entities (difference of 22) via anti-join against `entity-organisation.csv`, verify those entities belong to MHCLG in `lookup.csv`, and retire them
- Local-plan rule: If an LPA has entities above threshold 4220966, generate the fake reference ({authority-slug}-new-local-plan) using the organisation name, find the matching MHCLG entity in `lookup.csv`, cross-check it exists in `entity-organisation.csv`, and retire it
- In-place updates: LPAs that overwrote MHCLG data directly (entities below threshold) are skipped — no retirement needed since the fake data was replaced, not duplicated
- Validations: No overlap between retirement list and LPA data; completeness check (every LPA with new data has a matching template to retire); cross-check against `entity-organisation.csv`; fail if organisation names can't be resolved; skip duplicates already in `old-entity.csv`

Mineral plans and waste plans are out of scope as we did not create fake templates for them.

When run locally (19th May 2026), the script retires 189 entities:
- 184 from plan timetable (8 LPAs x 23 entities)
- 5 from local plans

This PR also places the script into a GitHub action, so it can be run ad-hoc. A PR will be produced - like with the Manage Conservation Area Data workflow - if entities are removed. If no entities are removed then no PR is produced.

**Requester's checklist:**
- [ ] Have checked if any old endpoints to retire
- [ ] Have validated endpoint (with check or endpoint checker)
- [ ] Have checked expected number of lookups
- [ ] Have checked for any geo duplicates (if CA data)
- [ ] Have updated entity-organisation.csv (if CA data)

**Reviewer's checklist:**
- [ ] Expected checks have been completed by PR requester
- [ ] Correct date format used in config files (YYYY-mm-dd)
- [ ] Number of new lookups is as expected from source data
- [ ] Spot checked that newly assigned entity numbers aren’t in use