### PR TITLE
Update notes/PR body for retiring fake MHCLG data

### DIFF
--- a/.github/scripts/retire-mhclg-plan-data.py
+++ b/.github/scripts/retire-mhclg-plan-data.py
@@ -84,7 +84,7 @@ def load_organisation_mapping():
 
 
 def retire_plan_timetable_data(lookup_rows, entity_org_rows):
-    """Retire MHCLG seeded data for plan-timetable dataset. Returns set of entities."""
+    """Retire MHCLG seeded data for plan-timetable dataset. Returns (entities, orgs)."""
     logger.info("\n=== Processing plan-timetable dataset ===")
 
     mhclg_range_min, mhclg_range_max = MHCLG_RANGES['plan-timetable']
@@ -98,7 +98,7 @@ def retire_plan_timetable_data(lookup_rows, entity_org_rows):
 
     if not all_lpa_rows:
         logger.warning(f"No LPA data found for {prefix}")
-        return set()
+        return set(), set()
 
     # Separate LPAs that created new data (outside MHCLG range) from those that
     # updated MHCLG data in-place (within MHCLG range). In-place updates don't
@@ -120,7 +120,7 @@ def retire_plan_timetable_data(lookup_rows, entity_org_rows):
 
     if not lpa_rows:
         logger.info("No LPAs with new data outside MHCLG range — nothing to retire")
-        return set()
+        return set(), set()
 
     min_lpa = min(int(r['entity']) for r in lpa_rows)
     max_lpa = max(int(r['entity']) for r in lpa_rows)
@@ -179,7 +179,7 @@ def retire_plan_timetable_data(lookup_rows, entity_org_rows):
 
     if not mhclg_to_retire:
         logger.info("No MHCLG entity ranges to retire for plan-timetable")
-        return set()
+        return set(), set()
 
     # Step 6: Expand ranges to individual entities and verify they are MHCLG
     entities_to_retire = set()
@@ -213,11 +213,11 @@ def retire_plan_timetable_data(lookup_rows, entity_org_rows):
     logger.info(f"✓ No overlap with LPA authoritative data")
 
     logger.info(f"✓ Verified and queued {len(entities_to_retire)} plan-timetable entities for retirement")
-    return entities_to_retire
+    return entities_to_retire, set(org_ranges.keys())
 
 
 def retire_local_plan_data(lookup_rows, entity_org_rows):
-    """Retire MHCLG seeded data for local-plan dataset. Returns set of entities."""
+    """Retire MHCLG seeded data for local-plan dataset. Returns (entities, orgs)."""
     logger.info("\n=== Processing local-plan dataset ===")
 
     mhclg_range_min, mhclg_range_max = MHCLG_RANGES['local-plan']
@@ -231,7 +231,7 @@ def retire_local_plan_data(lookup_rows, entity_org_rows):
 
     if not all_lpa_rows:
         logger.warning(f"No LPA data found for {prefix}")
-        return set()
+        return set(), set()
 
     # Separate LPAs that created new data (outside MHCLG range) from those that
     # updated MHCLG data in-place (within MHCLG range). In-place updates don't
@@ -253,7 +253,7 @@ def retire_local_plan_data(lookup_rows, entity_org_rows):
 
     if not lpa_rows:
         logger.info("No LPAs with new data outside MHCLG range — nothing to retire")
-        return set()
+        return set(), set()
 
     min_lpa = min(int(r['entity']) for r in lpa_rows)
     max_lpa = max(int(r['entity']) for r in lpa_rows)
@@ -368,7 +368,7 @@ def retire_local_plan_data(lookup_rows, entity_org_rows):
 
     logger.info(f"✓ All entities cross-checked against entity-organisation.csv")
     logger.info(f"✓ Queued {len(mhclg_entities)} local-plan entities for retirement")
-    return mhclg_entities
+    return mhclg_entities, lpa_orgs
 
 
 def save_retired_entities(entities_to_retire, old_entity_rows):
@@ -429,8 +429,8 @@ def main():
     logger.info(f"Loaded entity-organisation.csv ({len(entity_org_rows)} rows)")
     logger.info(f"Loaded old-entity.csv ({len(old_entity_rows)} rows)")
 
-    timetable_entities = retire_plan_timetable_data(lookup_rows, entity_org_rows)
-    local_plan_entities = retire_local_plan_data(lookup_rows, entity_org_rows)
+    timetable_entities, timetable_orgs = retire_plan_timetable_data(lookup_rows, entity_org_rows)
+    local_plan_entities, local_plan_orgs = retire_local_plan_data(lookup_rows, entity_org_rows)
 
     all_entities = timetable_entities | local_plan_entities
 
@@ -445,6 +445,20 @@ def main():
 
     save_retired_entities(all_entities, old_entity_rows)
     logger.info("\n✓ Retirement completed successfully")
+
+    # Print summary to stdout for use in PR body
+    print(f"Total entities retired: {len(all_entities)}")
+    print("")
+    if timetable_orgs:
+        print(f"**plan-timetable** ({len(timetable_entities)} entities):")
+        for org in sorted(timetable_orgs):
+            print(f"- {org}")
+        print("")
+    if local_plan_orgs:
+        print(f"**local-plan** ({len(local_plan_entities)} entities):")
+        for org in sorted(local_plan_orgs):
+            print(f"- {org}")
+        print("")
 
 
 if __name__ == '__main__':

--- a/.github/scripts/retire-mhclg-plan-data.py
+++ b/.github/scripts/retire-mhclg-plan-data.py
@@ -182,7 +182,7 @@ def retire_plan_timetable_data(lookup_rows, entity_org_rows):
         return set(), set()
 
     # Step 6: Expand ranges to individual entities and verify they are MHCLG
-    entities_to_retire = set()
+    entity_to_org = {}
 
     for org, entity_min, entity_max in mhclg_to_retire:
         mhclg_entities = [
@@ -200,11 +200,12 @@ def retire_plan_timetable_data(lookup_rows, entity_org_rows):
                 f"[{entity_min}, {entity_max}], found {len(mhclg_entities)}"
             )
 
-        entities_to_retire.update(mhclg_entities)
+        for e in mhclg_entities:
+            entity_to_org[e] = (org, prefix)
 
     # No-overlap check: ensure no entity being retired is also LPA authoritative data
     lpa_entity_set = set(int(r['entity']) for r in lpa_rows)
-    overlap = entities_to_retire & lpa_entity_set
+    overlap = set(entity_to_org.keys()) & lpa_entity_set
     if overlap:
         raise ValueError(
             f"ERROR: Entities {sorted(overlap)} are in BOTH the retirement list and "
@@ -212,8 +213,8 @@ def retire_plan_timetable_data(lookup_rows, entity_org_rows):
         )
     logger.info(f"✓ No overlap with LPA authoritative data")
 
-    logger.info(f"✓ Verified and queued {len(entities_to_retire)} plan-timetable entities for retirement")
-    return entities_to_retire, set(org_ranges.keys())
+    logger.info(f"✓ Verified and queued {len(entity_to_org)} plan-timetable entities for retirement")
+    return entity_to_org, set(org_ranges.keys())
 
 
 def retire_local_plan_data(lookup_rows, entity_org_rows):
@@ -282,7 +283,10 @@ def retire_local_plan_data(lookup_rows, entity_org_rows):
     logger.info(f"Generated {len(fake_plan_references)} fake plan references")
 
     # Step 3: Find MHCLG entities that match these fake plan references
-    mhclg_entities = set()
+    # Build reverse mapping: reference -> org
+    ref_to_org = {ref: org for org, ref in fake_plan_references.items()}
+
+    entity_to_org = {}
     for row in lookup_rows:
         if (row['organisation'] == MHCLG_ORG
                 and row['prefix'] == prefix
@@ -293,8 +297,9 @@ def retire_local_plan_data(lookup_rows, entity_org_rows):
                     f"ERROR: Found MHCLG entity {entity} outside expected range "
                     f"({mhclg_range_min}-{mhclg_range_max}). This indicates data corruption."
                 )
-            mhclg_entities.add(entity)
+            entity_to_org[entity] = (ref_to_org[row['reference']], prefix)
 
+    mhclg_entities = set(entity_to_org.keys())
     logger.info(f"Found {len(mhclg_entities)} MHCLG local plan entities to retire")
 
     # Completeness check: every LPA with data should have a MHCLG template entity
@@ -368,26 +373,26 @@ def retire_local_plan_data(lookup_rows, entity_org_rows):
 
     logger.info(f"✓ All entities cross-checked against entity-organisation.csv")
     logger.info(f"✓ Queued {len(mhclg_entities)} local-plan entities for retirement")
-    return mhclg_entities, lpa_orgs
+    return entity_to_org, lpa_orgs
 
 
-def save_retired_entities(entities_to_retire, old_entity_rows):
+def save_retired_entities(entity_to_org, old_entity_rows):
     """Append retired entities to old-entity.csv."""
-    logger.info(f"\n=== Saving {len(entities_to_retire)} entities to old-entity.csv ===")
+    logger.info(f"\n=== Saving {len(entity_to_org)} entities to old-entity.csv ===")
 
-    if not entities_to_retire:
+    if not entity_to_org:
         logger.warning("No entities to retire")
         return
 
     # Check for duplicates (entities already retired)
     existing = set(int(r['old-entity']) for r in old_entity_rows)
-    duplicates = entities_to_retire & existing
+    duplicates = set(entity_to_org.keys()) & existing
 
     if duplicates:
         logger.warning(f"⚠ {len(duplicates)} entities are already in old-entity.csv (skipping)")
-        entities_to_add = entities_to_retire - duplicates
+        entities_to_add = {e: org for e, org in entity_to_org.items() if e not in duplicates}
     else:
-        entities_to_add = entities_to_retire
+        entities_to_add = entity_to_org
 
     if not entities_to_add:
         logger.info("No new entities to add")
@@ -399,11 +404,12 @@ def save_retired_entities(entities_to_retire, old_entity_rows):
     with open(OLD_ENTITY_PATH, 'a', newline='', encoding='utf-8') as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         for entity_id in sorted(entities_to_add):
+            org, dataset = entities_to_add[entity_id]
             writer.writerow({
                 'old-entity': entity_id,
                 'status': 410,
                 'entity': '',
-                'notes': 'Retiring fake MHCLG template data',
+                'notes': f'Retiring fake MHCLG template data for {org}-{dataset}',
                 'end-date': '',
                 'entry-date': date.today().isoformat(),
                 'start-date': '',
@@ -429,33 +435,33 @@ def main():
     logger.info(f"Loaded entity-organisation.csv ({len(entity_org_rows)} rows)")
     logger.info(f"Loaded old-entity.csv ({len(old_entity_rows)} rows)")
 
-    timetable_entities, timetable_orgs = retire_plan_timetable_data(lookup_rows, entity_org_rows)
-    local_plan_entities, local_plan_orgs = retire_local_plan_data(lookup_rows, entity_org_rows)
+    timetable_entity_org, timetable_orgs = retire_plan_timetable_data(lookup_rows, entity_org_rows)
+    local_plan_entity_org, local_plan_orgs = retire_local_plan_data(lookup_rows, entity_org_rows)
 
-    all_entities = timetable_entities | local_plan_entities
+    all_entity_org = {**timetable_entity_org, **local_plan_entity_org}
 
     logger.info(f"\n=== Summary ===")
-    logger.info(f"plan-timetable: {len(timetable_entities)} entities")
-    logger.info(f"local-plan: {len(local_plan_entities)} entities")
-    logger.info(f"Total: {len(all_entities)} entities")
+    logger.info(f"plan-timetable: {len(timetable_entity_org)} entities")
+    logger.info(f"local-plan: {len(local_plan_entity_org)} entities")
+    logger.info(f"Total: {len(all_entity_org)} entities")
 
-    if not all_entities:
+    if not all_entity_org:
         logger.warning("No entities to retire")
         sys.exit(0)
 
-    save_retired_entities(all_entities, old_entity_rows)
+    save_retired_entities(all_entity_org, old_entity_rows)
     logger.info("\n✓ Retirement completed successfully")
 
     # Print summary to stdout for use in PR body
-    print(f"Total entities retired: {len(all_entities)}")
+    print(f"Total entities retired: {len(all_entity_org)}")
     print("")
     if timetable_orgs:
-        print(f"**plan-timetable** ({len(timetable_entities)} entities):")
+        print(f"**plan-timetable** ({len(timetable_entity_org)} entities):")
         for org in sorted(timetable_orgs):
             print(f"- {org}")
         print("")
     if local_plan_orgs:
-        print(f"**local-plan** ({len(local_plan_entities)} entities):")
+        print(f"**local-plan** ({len(local_plan_entity_org)} entities):")
         for org in sorted(local_plan_orgs):
             print(f"- {org}")
         print("")

--- a/.github/workflows/retire-mhclg-plan-data.yml
+++ b/.github/workflows/retire-mhclg-plan-data.yml
@@ -26,11 +26,17 @@ jobs:
           python-version: "3.11"
 
       - name: Run retire MHCLG plan data script
+        id: retire-script
         timeout-minutes: 10
         run: |
           echo "Starting retire MHCLG plan data script..."
-          python .github/scripts/retire-mhclg-plan-data.py
+          SUMMARY=$(python .github/scripts/retire-mhclg-plan-data.py)
           echo "Retire script completed"
+          {
+            echo "summary<<EOF"
+            echo "$SUMMARY"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Commit and create PR
         env:
@@ -62,14 +68,15 @@ jobs:
 
           # Create PR
           gh pr create --title "Retire MHCLG plan data" \
-            --body "This PR contains automatic updates to retire MHCLG template data:
+            --body "This PR retires fake MHCLG template data for LPAs that have provided authoritative data.
 
-          ## Changes
+          ## Organisations retired
 
-          **Retire MHCLG Plan Template Data:**
-          - Identifies LPAs that have provided authoritative data
-          - Removes pre-seeded MHCLG template entities for those LPAs
-          - For plan-timetable: Retires 23-entity ranges (22 local plan events)
+          ${{ steps.retire-script.outputs.summary }}
+
+          ## What this does
+
+          - For plan-timetable: Retires 23-entity ranges (23 local plan events)
           - For local-plan: Retires fake plan references (e.g., {slug}-new-local-plan)
           - Adds retired entities to old-entity.csv with status 410
 


### PR DESCRIPTION
## Data Template

**Ticket**
- Link: https://github.com/orgs/digital-land/projects/15?pane=issue&itemId=182257637&issue=digital-land%7Cconfig%7C2565

**Additional information:**
Iterating on https://github.com/digital-land/config/pull/2615

Small PR to update:
- When an entity is retired, include the organisation and dataset involved in the 'notes' of `old-entity.csv`
- In the PR that is automatically generated, include the organisations that have been retired in the PR body

`old-entity.csv` will now look like this:
<img width="665" height="360" alt="image" src="https://github.com/user-attachments/assets/c24cbcc1-b811-45bc-9e2f-d725fc35e335" />

And the PR body should appear like: 
<img width="276" height="303" alt="image" src="https://github.com/user-attachments/assets/f54e2acb-6bc9-4a93-912b-c8bf609cbd6a" />


**Requester's checklist:**
- [ ] Have checked if any old endpoints to retire
- [ ] Have validated endpoint (with check or endpoint checker)
- [ ] Have checked expected number of lookups
- [ ] Have checked for any geo duplicates (if CA data)
- [ ] Have updated entity-organisation.csv (if CA data)

**Reviewer's checklist:**
- [ ] Expected checks have been completed by PR requester
- [ ] Correct date format used in config files (YYYY-mm-dd)
- [ ] Number of new lookups is as expected from source data
- [ ] Spot checked that newly assigned entity numbers aren’t in use
