### PR TITLE
tests: edit test to flag if a new field missing from specification

### DIFF
--- a/tests/acceptance/test_config_dataset.py
+++ b/tests/acceptance/test_config_dataset.py
@@ -158,6 +158,12 @@ def _build_all_csv_rules(file_path, specification_dir):
         reader = csv.reader(f)
         header = next(reader)
         columns = [col.strip() for col in header]
+    
+    unregistered = [col for col in columns if col and col not in field_datatype]
+    if unregistered:
+        pytest.fail(
+            f"{Path(file_path).name}: columns not registered in specification: {unregistered}"
+        )
 
     for column in columns:
         datatype = field_datatype.get(column)


### PR DESCRIPTION
## Description

Edit acceptance test `_build_all_csv_rules` to check all fields in pipeline config csvs e.g expect, lookup, column, combine, transform, patch, filter, skip, etc, are also defined in in the specification repo, else the test throws an error identifying which field needs to be added to the specification repository.

## Why

As I discovered last week it is quite easy to add a new field to the config repo, not define it in specification, and then your field is silently removed, and any new functionality starts failing with an unclear cause. This error should give any new coder (or future me) a reminder that any new field being added to config must be defined in the specification repo. 

My understanding of the specification repository is that it should define every single field used across the whole of planning.data.gov.uk and as it seems we are imposing rules in the code to only use fields available in specification it seems reasonable to implement this as a test in config so that any code change will fail faster and safer. But do push back if this is a misconception from me.

## QA Instructions, Screenshots, Recordings: 

<img width="795" height="102" alt="image" src="https://github.com/user-attachments/assets/0f83cb8f-4ab0-48fd-90fc-5f0a6ff5281f" />



**Requester's checklist:**
- [ ] Have checked if any old endpoints to retire
- [ ] Have validated endpoint (with check or endpoint checker)
- [ ] Have checked expected number of lookups
- [ ] Have checked for any geo duplicates (if CA data)
- [ ] Have updated entity-organisation.csv (if CA data)

**Reviewer's checklist:**
- [ ] Expected checks have been completed by PR requester
- [ ] Correct date format used in config files (YYYY-mm-dd)
- [ ] Number of new lookups is as expected from source data
- [ ] Spot checked that newly assigned entity numbers aren’t in use
