### PR TITLE
Fix bugs in Manage CA data Github action

### DIFF
--- a/.github/scripts/deduplicate-ca-geogs.py
+++ b/.github/scripts/deduplicate-ca-geogs.py
@@ -142,7 +142,7 @@ def extract_complete_matches(df):
             'status': '301',
             'entity': row['entity_b'],
             'end-date': '',
-            'notes': 'Redirect old entity complete match to LPA entity',
+            'notes': f"Redirect old entity complete match to LPA entity: {row['lookup_org_b']}",
             'entry-date': today,
             'start-date': ''
         })
@@ -213,7 +213,7 @@ def extract_single_matches(df):
                 'status': '301',
                 'entity': row['entity_b'],
                 'end-date': '',
-                'notes': 'Redirect old entity single match to LPA entity',
+                'notes': f"Redirect old entity single match to LPA entity: {row['lookup_org_b']}",
                 'entry-date': today,
                 'start-date': ''
             })

--- a/.github/scripts/deduplicate-ca-geogs.py
+++ b/.github/scripts/deduplicate-ca-geogs.py
@@ -64,7 +64,7 @@ def stream_checks_data():
             # Columns we actually need for deduplication
             needed_columns = {
                 'message', 'dataset', 'entity_a', 'entity_b',
-                'entity_a_name', 'entity_b_name', 'lookup-org-a', 'lookup-org-b', 'in-odp'
+                'entity_a_name', 'entity_b_name', 'lookup_org_a', 'lookup_org_b', 'in_odp'
             }
 
             with open(temp_path, 'r', encoding='utf-8') as f:
@@ -128,8 +128,8 @@ def extract_complete_matches(df):
 
     complete_matches = [row for row in df if row['message'] == 'complete_match'
                         and row['dataset'] == 'conservation-area'
-                        and row.get('lookup-org-a') == 'government-organisation:PB1164'
-                        and row.get('lookup-org-b') != 'government-organisation:PB1164']
+                        and row.get('lookup_org_a') == 'government-organisation:PB1164'
+                        and row.get('lookup_org_b') != 'government-organisation:PB1164']
     print(f"Found {len(complete_matches)} complete matches")
 
     # Format for old-entity.csv
@@ -157,9 +157,9 @@ def extract_single_matches(df):
     # Filter for single matches in conservation-area
     single_matches = [row for row in df if row['message'] == 'single_match'
                       and row['dataset'] == 'conservation-area'
-                      and row.get('lookup-org-a') == 'government-organisation:PB1164'
-                      and row.get('lookup-org-b') != 'government-organisation:PB1164'
-                      and row.get('in-odp', '').lower() == 'true']
+                      and row.get('lookup_org_a') == 'government-organisation:PB1164'
+                      and row.get('lookup_org_b') != 'government-organisation:PB1164'
+                      and row.get('in_odp', '').lower() == 'true']
 
     print(f"Found {len(single_matches)} single matches meeting criteria")
 

--- a/.github/scripts/deduplicate-ca-geogs.py
+++ b/.github/scripts/deduplicate-ca-geogs.py
@@ -345,7 +345,7 @@ def save_output(data):
     """Save the updated data to CSV."""
     print(f"\nSaving to {OLD_ENTITY_PATH}...")
 
-    fieldnames = ['old-entity', 'status', 'entity', 'end-date', 'notes', 'entry-date', 'start-date']
+    fieldnames = ['old-entity', 'status', 'entity', 'notes', 'end-date', 'entry-date', 'start-date']
 
     with open(OLD_ENTITY_PATH, 'w', newline='', encoding='utf-8') as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)


### PR DESCRIPTION
## Data Template

**Ticket**
- Link: https://github.com/orgs/digital-land/projects/15/views/1?pane=issue&itemId=192737620&issue=digital-land%7Cconfig%7C2635

**Type**
- [ ] New data
- [ ] Data monitoring
- [X] Data/bug fix

**Expected outcome (if relevant):**
- [ ] New endpoint & source
- [ ] New lookups
- [ ] Extra endpoint config (e.g. column, concat)
- [ ] Retired old endpoint & source
- [X] Retired old entities
- [ ] Retired old resource

**Additional information:**
This PR address a couple of bugs within the Manage Conservation Area Data Github action:
- The `notes` and `end-date` columns were being accidentally swapped around
- Complete matches were not being redirected due to column name changes in the reporting-task repository

The PR also adds which organisations are associated with the 301 redirects in the `notes` column of `old-entity.csv`.

**Requester's checklist:**
- [ ] Have checked if any old endpoints to retire
- [ ] Have validated endpoint (with check or endpoint checker)
- [ ] Have checked expected number of lookups
- [ ] Have checked for any geo duplicates (if CA data)
- [ ] Have updated entity-organisation.csv (if CA data)

**Reviewer's checklist:**
- [ ] Expected checks have been completed by PR requester
- [ ] Correct date format used in config files (YYYY-mm-dd)
- [ ] Number of new lookups is as expected from source data
- [ ] Spot checked that newly assigned entity numbers aren’t in use
