### PR TITLE
Update batch assign schedule

### DIFF
--- a/.github/workflows/batch-assign.yml
+++ b/.github/workflows/batch-assign.yml
@@ -28,7 +28,7 @@ on:
       branch:
         description: "Git branch to use (optional)"
         required: false
-        default: "auto/batch-assign-entities"
+        default: "config-manager-update"
         type: string
       skip_checks:
         description: "Skip validation checks and directly assign entities (use with caution)"
@@ -80,6 +80,12 @@ jobs:
           pip install click pandas tqdm
           pip install -e "git+https://github.com/digital-land/digital-land-python.git@main#egg=digital-land"
 
+      - name: Fetch config-manager-update branch if it exists on remote
+        run: |
+          if git ls-remote --heads origin config-manager-update | grep -q config-manager-update; then
+            git fetch origin config-manager-update:config-manager-update
+          fi
+
       - name: Determine scope for scheduled run
         if: github.event_name == 'schedule'
         run: |
@@ -92,11 +98,13 @@ jobs:
             echo "SCHEDULED_SCOPE=odp" >> $GITHUB_ENV
           fi
 
+          echo "SCHEDULED_BRANCH=config-manager-update" >> $GITHUB_ENV
+
       - name: Run add-data script
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           RESOURCES: ${{ github.event.client_payload.resources || github.event.inputs.resources }}
-          BRANCH_PARAM: ${{ github.event.client_payload.branch || github.event.inputs.branch }}
+          BRANCH_PARAM: ${{ github.event.client_payload.branch || github.event.inputs.branch || env.SCHEDULED_BRANCH }}
           TRIGGERED_BY: ${{ github.actor || 'unknown' }}
           SCOPE: ${{ github.event.client_payload.scope || github.event.inputs.scope || env.SCHEDULED_SCOPE || 'odp' }}
           SKIP_CHECKS: ${{ github.event.client_payload.skip_checks || github.event.inputs.skip_checks }}

--- a/.github/workflows/batch-assign.yml
+++ b/.github/workflows/batch-assign.yml
@@ -45,6 +45,16 @@ on:
         required: false
         type: boolean
         default: true
+      batch_size:
+        description: "Resources per batch (single-source only). 0 = no batching."
+        required: false
+        type: number
+        default: 0
+      start_batch:
+        description: "Batch number to start from (single-source only). Use to resume a failed run."
+        required: false
+        type: number
+        default: 1
 
 jobs:
   auto-batch-assign:
@@ -94,6 +104,8 @@ jobs:
             echo "SCHEDULED_SCOPE=mandated" >> $GITHUB_ENV
           elif [ "$DAY" = "4" ]; then
             echo "SCHEDULED_SCOPE=single-source" >> $GITHUB_ENV
+            echo "SCHEDULED_BATCH_SIZE=10" >> $GITHUB_ENV
+            echo "SCHEDULED_START_BATCH=1" >> $GITHUB_ENV
           else
             echo "SCHEDULED_SCOPE=odp" >> $GITHUB_ENV
           fi
@@ -110,6 +122,8 @@ jobs:
           SKIP_CHECKS: ${{ github.event.client_payload.skip_checks || github.event.inputs.skip_checks }}
           NEW_ENTITIES_THRESHOLD: ${{ github.event.client_payload.new_entities_threshold || github.event.inputs.new_entities_threshold }}
           CREATE_PR: ${{ github.event.client_payload.create_pr || github.event.inputs.create_pr }}
+          BATCH_SIZE: ${{ github.event.client_payload.batch_size || github.event.inputs.batch_size || env.SCHEDULED_BATCH_SIZE || '0' }}
+          START_BATCH: ${{ github.event.client_payload.start_batch || github.event.inputs.start_batch || env.SCHEDULED_START_BATCH || '1' }}
         run: |
           if [ -n "$BRANCH_PARAM" ]; then
             ARGS+=(--branch "$BRANCH_PARAM")
@@ -137,7 +151,25 @@ jobs:
             ARGS+=(--no-create-pr)
           fi
 
-          python3 bin/batch_assign_entities.py "${ARGS[@]}"
+          if [ "${BATCH_SIZE:-0}" -gt 0 ]; then
+            CURRENT_BATCH="${START_BATCH:-1}"
+            while true; do
+              python3 bin/batch_assign_entities.py "${ARGS[@]}" \
+                --batch-size "$BATCH_SIZE" \
+                --start-batch "$CURRENT_BATCH"
+              EXIT=$?
+              if [ $EXIT -eq 2 ]; then
+                echo "All batches complete."
+                break
+              elif [ $EXIT -ne 0 ]; then
+                echo "::error::Batch $CURRENT_BATCH failed. To resume, trigger manually with: scope=$SCOPE, start_batch=$CURRENT_BATCH, batch_size=$BATCH_SIZE"
+                exit 1
+              fi
+              CURRENT_BATCH=$(( CURRENT_BATCH + 1 ))
+            done
+          else
+            python3 bin/batch_assign_entities.py "${ARGS[@]}"
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/batch-assign.yml
+++ b/.github/workflows/batch-assign.yml
@@ -1,40 +1,47 @@
 name: Batch Assign Unknown Entities
 
 on:
+  schedule:
+    - cron: "0 20 * * 1" # Monday    – odp
+    - cron: "0 20 * * 2" # Tuesday   – mandated
+    - cron: "0 20 * * 3" # Wednesday – odp
+    - cron: "0 20 * * 4" # Thursday  – single-source
+    - cron: "0 20 * * 5" # Friday    – odp
+
   repository_dispatch:
     types: [auto-batch-assign]
   workflow_dispatch:
     inputs:
       scope:
-        description: 'The scope of the batch assignment'
+        description: "The scope of the batch assignment"
         required: true
         type: choice
-        default: 'odp'
+        default: "odp"
         options:
-          - 'mandated'
-          - 'odp'
-          - 'single-source'
+          - "mandated"
+          - "odp"
+          - "single-source"
       resources:
-        description: 'Comma-separated list of resource '
+        description: "Comma-separated list of resource"
         required: false
         type: string
       branch:
-        description: 'Git branch to use (optional)'
+        description: "Git branch to use (optional)"
         required: false
-        default: 'auto/batch-assign-entities'
+        default: "auto/batch-assign-entities"
         type: string
       skip_checks:
-        description: 'Skip validation checks and directly assign entities (use with caution)'
+        description: "Skip validation checks and directly assign entities (use with caution)"
         required: false
         type: boolean
         default: false
       new_entities_threshold:
-        description: 'The percentage threshold for new entities to be assigned before triggering a warning (optional)'
+        description: "The percentage threshold for new entities to be assigned before triggering a warning (optional)"
         required: false
         type: number
         default: 10
       create_pr:
-        description: 'Whether to create a PR for the batch assignment results'
+        description: "Whether to create a PR for the batch assignment results"
         required: false
         type: boolean
         default: true
@@ -60,8 +67,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
-          cache: 'pip'
+          python-version: "3.9"
+          cache: "pip"
 
       - name: Install dependencies
         run: |
@@ -72,14 +79,26 @@ jobs:
           python -m pip install --upgrade pip
           pip install click pandas tqdm
           pip install -e "git+https://github.com/digital-land/digital-land-python.git@main#egg=digital-land"
-          
+
+      - name: Determine scope for scheduled run
+        if: github.event_name == 'schedule'
+        run: |
+          DAY=$(date +%u)  # 1=Mon, 2=Tue, 3=Wed, 4=Thu, 5=Fri
+          if [ "$DAY" = "2" ]; then
+            echo "SCHEDULED_SCOPE=mandated" >> $GITHUB_ENV
+          elif [ "$DAY" = "4" ]; then
+            echo "SCHEDULED_SCOPE=single-source" >> $GITHUB_ENV
+          else
+            echo "SCHEDULED_SCOPE=odp" >> $GITHUB_ENV
+          fi
+
       - name: Run add-data script
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           RESOURCES: ${{ github.event.client_payload.resources || github.event.inputs.resources }}
           BRANCH_PARAM: ${{ github.event.client_payload.branch || github.event.inputs.branch }}
           TRIGGERED_BY: ${{ github.actor || 'unknown' }}
-          SCOPE: ${{ github.event.client_payload.scope || github.event.inputs.scope || 'odp' }}
+          SCOPE: ${{ github.event.client_payload.scope || github.event.inputs.scope || env.SCHEDULED_SCOPE || 'odp' }}
           SKIP_CHECKS: ${{ github.event.client_payload.skip_checks || github.event.inputs.skip_checks }}
           NEW_ENTITIES_THRESHOLD: ${{ github.event.client_payload.new_entities_threshold || github.event.inputs.new_entities_threshold }}
           CREATE_PR: ${{ github.event.client_payload.create_pr || github.event.inputs.create_pr }}
@@ -122,4 +141,3 @@ jobs:
             issue_summary.csv
             invalid_uri_issues.csv
             issue_summary_full.csv
-            

--- a/bin/batch_assign_entities.py
+++ b/bin/batch_assign_entities.py
@@ -803,7 +803,7 @@ def run_batch_assign_entities(
     resources: Optional[str] = None,
     skip_checks: bool = False,
     triggered_by: Optional[str] = None,
-    branch: str = "auto/batch-assign-entities",
+    branch: str = "config-manager-update",
     create_pr: bool = True,
 ):
     endpoint_issue_summary_path = "https://datasette.planning.data.gov.uk/performance/endpoint_dataset_issue_type_summary.csv?_sort=rowid&issue_type__exact=unknown+entity&_size=max"
@@ -930,7 +930,7 @@ def run_batch_assign_entities(
     "--branch",
     required=False,
     type=str,
-    default='auto/batch-assign-entities',
+    default='config-manager-update',
     help="Git branch to use (optional metadata).",
 )
 @click.option(
@@ -966,7 +966,7 @@ def main(
     resources: Optional[str] = None,
     skip_checks: bool = False,
     triggered_by: Optional[str] = None,
-    branch: str = "auto/batch-assign-entities",
+    branch: str = "config-manager-update",
     create_pr: bool = True,
 ) -> None:
     # Print input options so the command and options used are visible

--- a/bin/batch_assign_entities.py
+++ b/bin/batch_assign_entities.py
@@ -1,4 +1,6 @@
 import csv
+import math
+import sys
 from time import perf_counter
 import click
 import requests
@@ -65,12 +67,15 @@ def checkout_branch_for_create_mode(branch_name):
         run_command(["git", "checkout", "-b", branch_name])
 
 
-def create_or_update_pr_for_success(branch, triggered_by, success_count, scope,body_suffix=""):
+def create_or_update_pr_for_success(branch, triggered_by, success_count, scope, body_suffix="", batch_size=0, start_batch=1):
     if not branch or branch.strip() == "":
         print(f"No --branch supplied; skipping PR creation :: {branch}")
         return
 
-    commit_label = f"{scope} - Batch assign entities update ({success_count} successful resource(s))"
+    if batch_size > 0:
+        commit_label = f"{scope} - Batch assign entities update (batch {start_batch}, {success_count} successful resource(s))"
+    else:
+        commit_label = f"{scope} - Batch assign entities update ({success_count} successful resource(s))"
 
     pr_body = (
         f"{commit_label}\n\n"
@@ -545,7 +550,7 @@ def _collect_validation_rows(current_resource_df, old_resource_df, dataset, reso
     return validation_rows, old_entities, new_entity_ids
 
 
-def process_csv(scope, resource_dir, issue_summary_df, cache_dir, new_entity_threshold=10, skip_checks=False,invalid_uri_issues=None):
+def process_csv(scope, resource_dir, issue_summary_df, cache_dir, new_entity_threshold=10, skip_checks=False, invalid_uri_issues=None, batch_size=0, start_batch=1):
     """
     Uses provided file path to automatically process and assign unknown entities
     """
@@ -756,7 +761,12 @@ def process_csv(scope, resource_dir, issue_summary_df, cache_dir, new_entity_thr
             finally:
                 print(f"\nCompleted processing for resource: {resource} in {perf_counter() - start_time:.2f} seconds.")
     finally:
-        output_df.to_csv(f"batch_assign_summary_{scope}.csv", index=False)
+        summary_filename = (
+            f"batch_assign_summary_{scope}_batch_{start_batch}.csv"
+            if batch_size > 0
+            else f"batch_assign_summary_{scope}.csv"
+        )
+        output_df.to_csv(summary_filename, index=False)
         # Remove successfully processed resources
         for resource_path in successful_resources:
             try:
@@ -805,6 +815,8 @@ def run_batch_assign_entities(
     triggered_by: Optional[str] = None,
     branch: str = "config-manager-update",
     create_pr: bool = True,
+    batch_size: int = 0,
+    start_batch: int = 1,
 ):
     endpoint_issue_summary_path = "https://datasette.planning.data.gov.uk/performance/endpoint_dataset_issue_type_summary.csv?_sort=rowid&issue_type__exact=unknown+entity&_size=max"
 
@@ -854,7 +866,25 @@ def run_batch_assign_entities(
     if resources:
         resource_set = {r.strip() for r in resources.split(",") if r.strip()}
         issue_summary_df = issue_summary_df[issue_summary_df["resource"].isin(resource_set)]
-    
+
+    # Deterministic ordering so batch numbers are stable across runs
+    issue_summary_df = issue_summary_df.sort_values("resource").reset_index(drop=True)
+
+    if batch_size > 0:
+        total_batches = math.ceil(len(issue_summary_df) / batch_size)
+        start_idx = (start_batch - 1) * batch_size
+        if start_idx >= len(issue_summary_df):
+            print(
+                f"Batch {start_batch} is out of range — "
+                f"only {total_batches} batch(es) exist for scope '{scope}'. Exiting."
+            )
+            sys.exit(2)
+        issue_summary_df = issue_summary_df.iloc[start_idx : start_idx + batch_size]
+        print(
+            f"Processing batch {start_batch} of {total_batches} "
+            f"({len(issue_summary_df)} resources)"
+        )
+
     if issue_summary_df.empty:
         print(f"No resources found with unknown entity issues for scope '{scope}'. Exiting.")
         return
@@ -884,7 +914,9 @@ def run_batch_assign_entities(
             cache_dir,
             new_entity_threshold,
             skip_checks,
-            invalid_uri_issues
+            invalid_uri_issues,
+            batch_size=batch_size,
+            start_batch=start_batch
         )
         error_count = len(output_df[output_df['status'] == 'error'])
         success_count = len(output_df[output_df['status'] == 'success'])
@@ -902,6 +934,8 @@ def run_batch_assign_entities(
                 success_count=success_count,
                 scope=scope,
                 body_suffix=body_suffix,
+                batch_size=batch_size,
+                start_batch=start_batch,
             )
         elif success_count > 0 and not create_pr:
             print("Successful assignments completed; PR creation disabled by --no-create-pr")
@@ -958,6 +992,20 @@ def run_batch_assign_entities(
     show_default=True,
     help="Create or update a PR when there are successful assignments.",
 )
+@click.option(
+    "--batch-size",
+    default=0,
+    type=int,
+    show_default=True,
+    help="Number of resources to process per run. 0 = process all (default).",
+)
+@click.option(
+    "--start-batch",
+    default=1,
+    type=int,
+    show_default=True,
+    help="1-indexed batch number to start from. Use with --batch-size to resume a failed run.",
+)
 
 def main(
     scope: str = 'odp',
@@ -968,6 +1016,8 @@ def main(
     triggered_by: Optional[str] = None,
     branch: str = "config-manager-update",
     create_pr: bool = True,
+    batch_size: int = 0,
+    start_batch: int = 1,
 ) -> None:
     # Print input options so the command and options used are visible
     print("Input options:")
@@ -979,6 +1029,8 @@ def main(
     print(f"  triggered_by={triggered_by}")
     print(f"  branch={branch}")
     print(f"  create_pr={create_pr}")
+    print(f"  batch_size={batch_size}")
+    print(f"  start_batch={start_batch}")
 
     cache_dir = Path(cache_dir)
     run_batch_assign_entities(
@@ -990,6 +1042,8 @@ def main(
         triggered_by=triggered_by,
         branch=branch,
         create_pr=create_pr,
+        batch_size=batch_size,
+        start_batch=start_batch,
     )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Data Template

**Ticket**
- Link: https://github.com/orgs/digital-land/projects/15?pane=issue&itemId=178131831&issue=digital-land%7Cconfig-manager%7C143

## Additional information

This PR updates the [Batch Assign Unknown Entities GitHub action](https://github.com/digital-land/config/actions/workflows/batch-assign.yml) and the underlying `bin/batch_assign_entities.py` script.

### Scheduled triggers

The action now runs automatically every evening at 8pm UTC alongside the existing manual trigger, with the dataset scope determined by day of the week:

- ODP: Mon/Wed/Fri
- Mandated: Tues
- Single Source: Thurs

### Branch behaviour

The default branch has been changed from `auto/batch-assign-entities` to `config-manager-update` in both the workflow and the script. A new step runs on every trigger (manual or scheduled) that checks whether `config-manager-update` already exists on the remote. If it does, it fetches it locally before the script runs — meaning the script will commit onto the existing branch and update its open PR rather than creating a new one. If the branch doesn't exist, the script creates it from `main` as before.

### Batching for single-source

The single-source scope can cause GitHub Actions to time out (2hr limit) because some resources involve large Datasette queries. To mitigate this, scheduled Thursday runs now process resources in batches of 10. Resources are sorted deterministically by hash before batching, so batch numbers are stable and reproducible across runs.

The workflow loops through batches automatically. Each batch commits its changes to `config-manager-update` before the next batch begins — so if the job times out or a batch fails, all previously completed batches are already saved. The failed batch number is printed in the workflow error log, e.g.:

`Batch 4 failed. To resume, trigger manually with: scope=single-source, start_batch=4, batch_size=10`

Two new parameters have been added to the manual trigger to support resuming:
- `batch_size` — number of resources per batch (default `0` = no batching, used for odp/mandated)
- `start_batch` — which batch to start from (default `1`)

Each batch produces its own summary artifact (`batch_assign_summary_single-source_batch_N.csv`) and commit message (`single-source - Batch assign entities update (batch N, X successful resource(s))`).

Batching is **not** applied to odp or mandated scheduled runs — those continue to process all resources in a single run as before.