### PR TITLE
Fix bugs in updated batch assign action

### DIFF
--- a/bin/batch_assign_entities.py
+++ b/bin/batch_assign_entities.py
@@ -125,7 +125,7 @@ def create_or_update_pr_for_success(branch, triggered_by, success_count, scope, 
             capture_output=True,
         )
         new_body = f"{current_body}\n\n{pr_body}" if current_body else pr_body
-        run_command(["gh", "pr", "edit", pr_number, "--title", f"{scope} - Batch Assign Entities Update", "--body", new_body])
+        run_command(["gh", "pr", "edit", pr_number, "--body", new_body])
         print(f"Updated existing PR #{pr_number} on branch {branch}")
         return
 

--- a/bin/batch_assign_entities.py
+++ b/bin/batch_assign_entities.py
@@ -85,6 +85,8 @@ def create_or_update_pr_for_success(branch, triggered_by, success_count, scope, 
 
     run_command(["git", "config", "user.name", "github-actions-add-data-bot"])
     run_command(["git", "config", "user.email", "matthew.poole@communities.gov.uk"])
+
+    original_branch = run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"], capture_output=True)
     checkout_branch_for_create_mode(branch)
 
     run_command(["git", "add", "pipeline/"])
@@ -97,10 +99,12 @@ def create_or_update_pr_for_success(branch, triggered_by, success_count, scope, 
 
     if not staged_changes:
         print("No staged changes after batch assignment; skipping PR creation")
+        run_command(["git", "checkout", original_branch])
         return
 
     run_command(["git", "commit", "-m", commit_label])
     run_command(["git", "push", "origin", branch])
+    run_command(["git", "checkout", original_branch])
 
     pr_number = run_command(
         [


### PR DESCRIPTION
## Data Template

**Ticket**
- Link: https://github.com/orgs/digital-land/projects/15/views/1?pane=issue&itemId=178131831&issue=digital-land%7Cconfig-manager%7C143

**Type**
- [ ] New data
- [ ] Data monitoring
- [X] Fix

**Additional information:**
Small PR to fix two bugs in the batch assign changes I made in #2644:
- When a config-manager-update branch and PR already exists, keep the existing PR name
- When batching single-source data, once a batch has been processed and commited to config-manager-update, return back to the main branch to continue the processing of the next batch. _This will help with any code version differences between config-manager-update and the main branch._