### PR TITLE
Remove the swap to main branch after each single-source batch

### DIFF
--- a/.github/workflows/batch-assign.yml
+++ b/.github/workflows/batch-assign.yml
@@ -152,9 +152,19 @@ jobs:
           fi
 
           if [ "${BATCH_SIZE:-0}" -gt 0 ]; then
+            # Save the script before git checkout may overwrite it with an older version
+            cp bin/batch_assign_entities.py /tmp/batch_assign_entities.py
+
+            # Switch to config-manager-update so pipeline files accumulate correctly across batches
+            if git show-ref --verify --quiet refs/heads/config-manager-update; then
+              git checkout config-manager-update
+            else
+              git checkout -b config-manager-update
+            fi
+
             CURRENT_BATCH="${START_BATCH:-1}"
             while true; do
-              python3 bin/batch_assign_entities.py "${ARGS[@]}" \
+              python3 /tmp/batch_assign_entities.py "${ARGS[@]}" \
                 --batch-size "$BATCH_SIZE" \
                 --start-batch "$CURRENT_BATCH"
               EXIT=$?

--- a/bin/batch_assign_entities.py
+++ b/bin/batch_assign_entities.py
@@ -85,8 +85,6 @@ def create_or_update_pr_for_success(branch, triggered_by, success_count, scope, 
 
     run_command(["git", "config", "user.name", "github-actions-add-data-bot"])
     run_command(["git", "config", "user.email", "matthew.poole@communities.gov.uk"])
-
-    original_branch = run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"], capture_output=True)
     checkout_branch_for_create_mode(branch)
 
     run_command(["git", "add", "pipeline/"])
@@ -99,12 +97,10 @@ def create_or_update_pr_for_success(branch, triggered_by, success_count, scope, 
 
     if not staged_changes:
         print("No staged changes after batch assignment; skipping PR creation")
-        run_command(["git", "checkout", original_branch])
         return
 
     run_command(["git", "commit", "-m", commit_label])
     run_command(["git", "push", "origin", branch])
-    run_command(["git", "checkout", original_branch])
 
     pr_number = run_command(
         [


### PR DESCRIPTION
## Data Template

**Ticket**
- Link: #2648 

**Additional information:**
Upon testing the changes in #2648, the action failed again. The initial fix after batch 1 committed switched the working directory back to main. This meant batch 2 processed pipeline files from main's older state rather than building on top of batch 1's work. When batch 2 then tried to commit to config-manager-update, git refused because the working tree had conflicting versions of the same pipeline files.

This PR fix keeps the working directory on config-manager-update for the entire batch run, and saves the script to /tmp before the first git checkout so the newer version (with --batch-size) isn't overwritten by the older one on config-manager-update.