### PR TITLE
Apply branch switching to all data scopes

### DIFF
--- a/.github/workflows/batch-assign.yml
+++ b/.github/workflows/batch-assign.yml
@@ -154,17 +154,17 @@ jobs:
             ARGS+=(--no-create-pr)
           fi
 
+          # Save the script before git checkout may overwrite it with an older version
+          cp .github/scripts/batch_assign_entities.py /tmp/batch_assign_entities.py
+
+          # Switch to config-manager-update so pipeline files are at the correct state
+          if git show-ref --verify --quiet refs/heads/config-manager-update; then
+            git checkout config-manager-update
+          else
+            git checkout -b config-manager-update
+          fi
+
           if [ "${BATCH_SIZE:-0}" -gt 0 ]; then
-            # Save the script before git checkout may overwrite it with an older version
-            cp .github/scripts/batch_assign_entities.py /tmp/batch_assign_entities.py
-
-            # Switch to config-manager-update so pipeline files accumulate correctly across batches
-            if git show-ref --verify --quiet refs/heads/config-manager-update; then
-              git checkout config-manager-update
-            else
-              git checkout -b config-manager-update
-            fi
-
             CURRENT_BATCH="${START_BATCH:-1}"
             while true; do
               set +e
@@ -183,7 +183,7 @@ jobs:
               CURRENT_BATCH=$(( CURRENT_BATCH + 1 ))
             done
           else
-            python3 .github/scripts/batch_assign_entities.py "${ARGS[@]}"
+            python3 /tmp/batch_assign_entities.py "${ARGS[@]}"
           fi
 
       - name: Upload artifact


### PR DESCRIPTION
**Additional information:**
This PR fixes the batch entity assign [action](https://github.com/digital-land/config/actions/runs/26910069969/job/79385403115), where the `odp` or `mandated` data scope is selected and there's a current config-manager-update branch/PR open. The action failed last night because the action did not want to overwrite any data on the config-manager-update branch.
My fixes yesterday in #2652 were applied to just `single-source`, so this PR expands that code fix to all data scopes.