### PR TITLE
Fix scheduling actions

### DIFF
--- a/.github/scripts/batch_assign_entities.py
+++ b/.github/scripts/batch_assign_entities.py
@@ -46,46 +46,14 @@ def run_command(cmd, capture_output=True, check=True):
     return (result.stdout or "").strip() if capture_output else ""
 
 
-def checkout_branch_for_create_mode(branch_name):
-    current_branch = run_command(
-        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-        capture_output=True,
-    )
-    if current_branch == branch_name:
-        return
-
-    local_exists = subprocess.run(
-        ["git", "show-ref", "--verify", f"refs/heads/{branch_name}"],
-        text=True,
-        capture_output=True,
-        check=False,
-    ).returncode == 0
-
-    if local_exists:
-        run_command(["git", "checkout", branch_name])
-    else:
-        run_command(["git", "checkout", "-b", branch_name])
-
-
-def create_or_update_pr_for_success(branch, triggered_by, success_count, scope, body_suffix="", batch_size=0, start_batch=1):
-    if not branch or branch.strip() == "":
-        print(f"No --branch supplied; skipping PR creation :: {branch}")
-        return
-
+def commit_to_main(triggered_by, success_count, scope, batch_size=0, start_batch=1):
     if batch_size > 0:
         commit_label = f"{scope} - Batch assign entities update (batch {start_batch}, {success_count} successful resource(s))"
     else:
         commit_label = f"{scope} - Batch assign entities update ({success_count} successful resource(s))"
 
-    pr_body = (
-        f"{commit_label}\n\n"
-        f"Triggered by: {triggered_by}\n\n"
-        f"{body_suffix}\n\n"
-    )
-
-    run_command(["git", "config", "user.name", "github-actions-add-data-bot"])
-    run_command(["git", "config", "user.email", "matthew.poole@communities.gov.uk"])
-    checkout_branch_for_create_mode(branch)
+    run_command(["git", "config", "user.name", "github-actions-bot"])
+    run_command(["git", "config", "user.email", "noreply@github.com"])
 
     run_command(["git", "add", "pipeline/"])
     run_command(["git", "add", "collection/"], check=False)
@@ -96,55 +64,12 @@ def create_or_update_pr_for_success(branch, triggered_by, success_count, scope, 
     ).returncode != 0
 
     if not staged_changes:
-        print("No staged changes after batch assignment; skipping PR creation")
+        print("No staged changes after batch assignment; skipping commit")
         return
 
     run_command(["git", "commit", "-m", commit_label])
-    run_command(["git", "push", "origin", branch])
-
-    pr_number = run_command(
-        [
-            "gh",
-            "pr",
-            "list",
-            "--head",
-            branch,
-            "--state",
-            "open",
-            "--json",
-            "number",
-            "--jq",
-            ".[0].number // empty",
-        ],
-        capture_output=True,
-    )
-
-    if pr_number:
-        current_body = run_command(
-            ["gh", "pr", "view", pr_number, "--json", "body", "--jq", ".body"],
-            capture_output=True,
-        )
-        new_body = f"{current_body}\n\n{pr_body}" if current_body else pr_body
-        run_command(["gh", "pr", "edit", pr_number, "--body", new_body])
-        print(f"Updated existing PR #{pr_number} on branch {branch}")
-        return
-
-    run_command(
-        [
-            "gh",
-            "pr",
-            "create",
-            "--title",
-            f"{scope} - Batch Assign Entities Update",
-            "--body",
-            pr_body,
-            "--base",
-            "main",
-            "--head",
-            branch,
-        ]
-    )
-    print(f"Created PR on branch {branch}")
+    run_command(["git", "push", "origin", "HEAD:main"])
+    print(f"Committed and pushed to main: {commit_label}")
 
 def download_file(url, output_path, raise_error=False, max_retries=5):
     """Downloads a file using urllib and saves it to the output directory. msj151225"""
@@ -813,8 +738,7 @@ def run_batch_assign_entities(
     resources: Optional[str] = None,
     skip_checks: bool = False,
     triggered_by: Optional[str] = None,
-    branch: str = "config-manager-update",
-    create_pr: bool = True,
+    commit: bool = True,
     batch_size: int = 0,
     start_batch: int = 1,
 ):
@@ -849,8 +773,6 @@ def run_batch_assign_entities(
 
     if triggered_by:
         print(f"Triggered by: {triggered_by}")
-    if branch:
-        print(f"Branch parameter: {branch}")
     print("issue_summary.csv downloaded successfully")
     
     # Build url_map from the CSV data
@@ -925,22 +847,18 @@ def run_batch_assign_entities(
         print(f"Total failed assign-entities operations: {error_count}")
         print(f"Total successful assign-entities operations: {success_count}")
 
-        if success_count > 0 and create_pr:
-            body_suffix = f"{success_count} successful resource(s) processed with batch assign entities for scope '{scope}'."
-            f"Options used to run this command: \n\n scope: {scope} \n new_entity_threshold: {new_entity_threshold} \n skip_checks: {skip_checks} \n resources: {resources} \n branch: {branch} \n triggered_by: {triggered_by} \n create_pr: {create_pr} \n\n"
-            create_or_update_pr_for_success(
-                branch=branch,
+        if success_count > 0 and commit:
+            commit_to_main(
                 triggered_by=triggered_by,
                 success_count=success_count,
                 scope=scope,
-                body_suffix=body_suffix,
                 batch_size=batch_size,
                 start_batch=start_batch,
             )
-        elif success_count > 0 and not create_pr:
-            print("Successful assignments completed; PR creation disabled by --no-create-pr")
+        elif success_count > 0 and not commit:
+            print("Successful assignments completed; --no-commit set, skipping commit to main")
         else:
-            print("No successful assignments; skipping PR creation")
+            print("No successful assignments; skipping commit to main")
     except Exception as e:
         print(f"Error running batch assign entities: {e}")
         traceback.print_exc()
@@ -959,13 +877,6 @@ def run_batch_assign_entities(
     required=False,
     type=str,
     help="Identifier for the actor/system that triggered this run.",
-)
-@click.option(
-    "--branch",
-    required=False,
-    type=str,
-    default='config-manager-update',
-    help="Git branch to use (optional metadata).",
 )
 @click.option(
     "--resources",
@@ -987,10 +898,10 @@ def run_batch_assign_entities(
     help="The threshold for the number of new entities to be assigned in percentage compared to the previous version of the resource.",
 )
 @click.option(
-    "--create-pr/--no-create-pr",
+    "--commit/--no-commit",
     default=True,
     show_default=True,
-    help="Create or update a PR when there are successful assignments.",
+    help="Commit changes to main when there are successful assignments.",
 )
 @click.option(
     "--batch-size",
@@ -1014,8 +925,7 @@ def main(
     resources: Optional[str] = None,
     skip_checks: bool = False,
     triggered_by: Optional[str] = None,
-    branch: str = "config-manager-update",
-    create_pr: bool = True,
+    commit: bool = True,
     batch_size: int = 0,
     start_batch: int = 1,
 ) -> None:
@@ -1027,8 +937,7 @@ def main(
     print(f"  resources={resources}")
     print(f"  skip_checks={skip_checks}")
     print(f"  triggered_by={triggered_by}")
-    print(f"  branch={branch}")
-    print(f"  create_pr={create_pr}")
+    print(f"  commit={commit}")
     print(f"  batch_size={batch_size}")
     print(f"  start_batch={start_batch}")
 
@@ -1040,8 +949,7 @@ def main(
         resources=resources,
         skip_checks=skip_checks,
         triggered_by=triggered_by,
-        branch=branch,
-        create_pr=create_pr,
+        commit=commit,
         batch_size=batch_size,
         start_batch=start_batch,
     )

--- a/.github/workflows/auto-merge-config-manager.yml
+++ b/.github/workflows/auto-merge-config-manager.yml
@@ -1,0 +1,77 @@
+name: Auto-merge config-manager-update
+
+on:
+  schedule:
+    - cron: "30 18 * * *" # 6:30pm UTC daily
+
+env:
+  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Check for PR from config-manager-update to main
+        id: check-pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          PR_NUMBER=$(gh pr list \
+            --head config-manager-update \ 
+            --base main \
+            --json number \
+            --jq '.[0].number' || echo "")
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "pr_exists=false" >> $GITHUB_OUTPUT
+            echo "No PR found for config-manager-update → main"
+          else
+            echo "pr_exists=true" >> $GITHUB_OUTPUT
+            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "Found PR #$PR_NUMBER"
+          fi
+
+      - name: Approve PR
+        if: steps.check-pr.outputs.pr_exists == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr review ${{ steps.check-pr.outputs.pr_number }} \
+            --approve \
+            --body "Auto-approved by workflow"
+
+      - name: Merge PR with squash
+        if: steps.check-pr.outputs.pr_exists == 'true'
+        id: merge
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr merge ${{ steps.check-pr.outputs.pr_number }} \
+            --squash \
+            --delete-branch \
+            --admin && echo "merge_success=true" >> $GITHUB_OUTPUT || echo "merge_success=false" >> $GITHUB_OUTPUT
+
+      - name: Notify Slack on merge failure
+        if: steps.check-pr.outputs.pr_exists == 'true' && steps.merge.outputs.merge_success == 'false'
+        uses: digital-land/github-action-slack-notify-build@main
+        with:
+          channel: planning-data-alerts
+          status: FAILED
+          color: danger
+          message: |
+            Failed to merge config-manager-update → main (likely due to conflicts).
+            PR: https://github.com/${{ github.repository }}/pull/${{ steps.check-pr.outputs.pr_number }}
+            Please resolve conflicts and merge manually.

--- a/.github/workflows/batch-assign.yml
+++ b/.github/workflows/batch-assign.yml
@@ -28,11 +28,6 @@ on:
         description: "Comma-separated list of resource"
         required: false
         type: string
-      branch:
-        description: "Git branch to use (optional)"
-        required: false
-        default: "config-manager-update"
-        type: string
       skip_checks:
         description: "Skip validation checks and directly assign entities (use with caution)"
         required: false
@@ -43,8 +38,8 @@ on:
         required: false
         type: number
         default: 10
-      create_pr:
-        description: "Whether to create a PR for the batch assignment results"
+      commit:
+        description: "Whether to commit results to main (set to false for dry runs)"
         required: false
         type: boolean
         default: true
@@ -76,6 +71,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
+          ref: main
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -93,12 +89,6 @@ jobs:
           pip install click pandas tqdm
           pip install -e "git+https://github.com/digital-land/digital-land-python.git@main#egg=digital-land"
 
-      - name: Fetch config-manager-update branch if it exists on remote
-        run: |
-          if git ls-remote --heads origin config-manager-update | grep -q config-manager-update; then
-            git fetch origin config-manager-update:config-manager-update
-          fi
-
       - name: Determine scope for scheduled run
         if: github.event_name == 'schedule'
         run: |
@@ -113,25 +103,18 @@ jobs:
             echo "SCHEDULED_SCOPE=odp" >> $GITHUB_ENV
           fi
 
-          echo "SCHEDULED_BRANCH=config-manager-update" >> $GITHUB_ENV
-
       - name: Run add-data script
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           RESOURCES: ${{ github.event.client_payload.resources || github.event.inputs.resources }}
-          BRANCH_PARAM: ${{ github.event.client_payload.branch || github.event.inputs.branch || env.SCHEDULED_BRANCH }}
           TRIGGERED_BY: ${{ github.actor || 'unknown' }}
           SCOPE: ${{ github.event.client_payload.scope || github.event.inputs.scope || env.SCHEDULED_SCOPE || 'odp' }}
           SKIP_CHECKS: ${{ github.event.client_payload.skip_checks || github.event.inputs.skip_checks }}
           NEW_ENTITIES_THRESHOLD: ${{ github.event.client_payload.new_entities_threshold || github.event.inputs.new_entities_threshold }}
-          CREATE_PR: ${{ github.event.client_payload.create_pr || github.event.inputs.create_pr }}
+          COMMIT: ${{ github.event.client_payload.commit || github.event.inputs.commit }}
           BATCH_SIZE: ${{ github.event.client_payload.batch_size || github.event.inputs.batch_size || env.SCHEDULED_BATCH_SIZE || '0' }}
           START_BATCH: ${{ github.event.client_payload.start_batch || github.event.inputs.start_batch || env.SCHEDULED_START_BATCH || '1' }}
         run: |
-          if [ -n "$BRANCH_PARAM" ]; then
-            ARGS+=(--branch "$BRANCH_PARAM")
-          fi
-
           ARGS+=(--scope "$SCOPE")
 
           if [ -n "$RESOURCES" ]; then
@@ -150,25 +133,15 @@ jobs:
             ARGS+=(--triggered-by "$TRIGGERED_BY")
           fi
 
-          if [[ "$CREATE_PR" == "false" ]]; then
-            ARGS+=(--no-create-pr)
-          fi
-
-          # Save the script before git checkout may overwrite it with an older version
-          cp .github/scripts/batch_assign_entities.py /tmp/batch_assign_entities.py
-
-          # Switch to config-manager-update so pipeline files are at the correct state
-          if git show-ref --verify --quiet refs/heads/config-manager-update; then
-            git checkout config-manager-update
-          else
-            git checkout -b config-manager-update
+          if [[ "$COMMIT" == "false" ]]; then
+            ARGS+=(--no-commit)
           fi
 
           if [ "${BATCH_SIZE:-0}" -gt 0 ]; then
             CURRENT_BATCH="${START_BATCH:-1}"
             while true; do
               set +e
-              python3 /tmp/batch_assign_entities.py "${ARGS[@]}" \
+              python3 .github/scripts/batch_assign_entities.py "${ARGS[@]}" \
                 --batch-size "$BATCH_SIZE" \
                 --start-batch "$CURRENT_BATCH"
               EXIT=$?
@@ -183,7 +156,7 @@ jobs:
               CURRENT_BATCH=$(( CURRENT_BATCH + 1 ))
             done
           else
-            python3 /tmp/batch_assign_entities.py "${ARGS[@]}"
+            python3 .github/scripts/batch_assign_entities.py "${ARGS[@]}"
           fi
 
       - name: Upload artifact


### PR DESCRIPTION
## Data Template

**Ticket**
- Link: 

**Type**
- [ ] New data
- [ ] Data monitoring
- [X] Fix

**Additional information:**
This PR aims to fix the Batch Assign Github action and create a new Github action for auto-merging the `config-manager-update` branch every evening.

---

### Fix Batch Assign Github action 
We noticed that merge conflicts were happening between the Batch Assign action, and the Standardise CSV action which is scheduled to happen after the Batch Assign action. After talking to Ben and Swati, we decided to:
- Automatically merge any changes from the Batch Assign action straight into the main branch

---

### New Auto-merge Workflow (auto-merge-config-manager.yml)
Purpose: Automatically approve and merge the config-manager-update branch to main daily before batch-assign runs.

Behavior:
- Runs at 6:30pm UTC daily (30 minutes before batch-assign at 7:00pm)
- Checks for existing PR from config-manager-update → main
- If PR exists: approves it, merges with squash strategy, deletes branch
- If merge fails (conflicts): skips merge and notifies planning-data-alerts Slack channel
- If no PR exists: does nothing