### PR TITLE
Minor Batch Entity bug fixes

### DIFF
--- a/.github/scripts/batch_assign_entities.py
+++ b/.github/scripts/batch_assign_entities.py
@@ -68,6 +68,7 @@ def commit_to_main(triggered_by, success_count, scope, batch_size=0, start_batch
         return
 
     run_command(["git", "commit", "-m", commit_label])
+    run_command(["git", "pull", "--rebase", "origin", "main"])
     run_command(["git", "push", "origin", "HEAD:main"])
     print(f"Committed and pushed to main: {commit_label}")
 

--- a/.github/workflows/batch-assign.yml
+++ b/.github/workflows/batch-assign.yml
@@ -104,6 +104,7 @@ jobs:
           fi
 
       - name: Run add-data script
+        id: batch-assign
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           RESOURCES: ${{ github.event.client_payload.resources || github.event.inputs.resources }}
@@ -158,6 +159,8 @@ jobs:
           else
             python3 .github/scripts/batch_assign_entities.py "${ARGS[@]}"
           fi
+          echo "scope=$SCOPE" >> $GITHUB_OUTPUT
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -177,3 +180,4 @@ jobs:
           channel: planning-data-alerts
           status: FAILED
           color: danger
+          message: "Batch Assign Unknown Entities - ${{ steps.batch-assign.outputs.scope }} workflow on config"


### PR DESCRIPTION
## Data Template

**Type**
- [ ] New data
- [ ] Data monitoring
- [X] Data fix

**Additional information:**
This PR fixes a couple of bugs we have found on the Batch Entity action:
- Adds which data scope (odp, mandated or single-source) failed on the Slack notification message
- Rebases to main before pushing changes to main. This will help if there are any PR merges into main when the action is mid-way through a run
