### PR TITLE
feat: Add support for entity redirects in async data processing

### DIFF
--- a/.github/workflows/add-data-async-script.yml
+++ b/.github/workflows/add-data-async-script.yml
@@ -30,6 +30,10 @@ on:
         description: 'Comma-separated endpoint strings to retire (optional)'
         required: false
         type: string
+      entity_redirects:
+        description: 'JSON duplicate entity redirects to append to old-entity.csv (optional)'
+        required: false
+        type: string
       test:
         description: 'Run in test mode (creates draft PR)'
         required: false
@@ -72,6 +76,7 @@ jobs:
           TRIGGERED_BY: ${{ github.event.client_payload.triggered_by || github.event.inputs.triggered_by }}
           ENVIRONMENT: ${{ github.event.client_payload.environment || github.event.inputs.environment || 'staging' }}
           RETIRE_ENDPOINTS: ${{ github.event.client_payload.retire_endpoints || github.event.inputs.retire_endpoints }}
+          ENTITY_REDIRECTS: ${{ github.event.client_payload.entity_redirects || github.event.inputs.entity_redirects }}
           TEST_MODE: ${{ github.event.inputs.test }}
         run: |
           ARGS=(
@@ -87,6 +92,10 @@ jobs:
 
           if [ -n "$RETIRE_ENDPOINTS" ]; then
             ARGS+=(--retire-endpoints "$RETIRE_ENDPOINTS")
+          fi
+
+          if [ -n "$ENTITY_REDIRECTS" ]; then
+            ARGS+=(--entity-redirects "$ENTITY_REDIRECTS")
           fi
 
           if [ "$TEST_MODE" = "true" ]; then

--- a/bin/add_data.py
+++ b/bin/add_data.py
@@ -20,6 +20,15 @@ API_BASE_URL_BY_ENVIRONMENT = {
     "production": "http://production-pub-async-api-lb-636110663.eu-west-2.elb.amazonaws.com",
 }
 DEFAULT_ENVIRONMENT = "staging"
+OLD_ENTITY_HEADER = [
+    "old-entity",
+    "status",
+    "entity",
+    "notes",
+    "end-date",
+    "entry-date",
+    "start-date",
+]
 
 
 def resolve_api_base_url(environment: str) -> str:
@@ -111,6 +120,74 @@ def normalize_retire_endpoints(value: object) -> list[str]:
     if isinstance(value, list):
         return [str(item).strip() for item in value if str(item).strip()]
     return []
+
+
+def normalize_entity_redirects(value: object) -> list[dict[str, str]]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        if not value.strip():
+            return []
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            fail(f"Failed to parse entity redirects JSON: {exc}")
+    if not isinstance(value, list):
+        return []
+
+    redirects = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        old_entity = str(item.get("old_entity", "") or "").strip()
+        entity = str(item.get("entity", "") or "").strip()
+        if not old_entity or not entity:
+            continue
+        redirects.append(
+            {
+                "old_entity": old_entity,
+                "entity": entity,
+                "notes": item.get("notes", ""),
+            }
+        )
+    return redirects
+
+
+def append_entity_redirects(collection: str, entity_redirects: list[dict[str, str]]) -> None:
+    if not entity_redirects:
+        return
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    old_entity_file = Path("pipeline") / collection / "old-entity.csv"
+    if old_entity_file.exists():
+        frame = pd.read_csv(old_entity_file, dtype=str, keep_default_na=False)
+        existing_old_entities = set(frame.get("old-entity", []))
+    else:
+        old_entity_file.write_text(",".join(OLD_ENTITY_HEADER) + "\r\n", encoding="utf-8")
+        existing_old_entities = set()
+
+    rows = []
+    for redirect in entity_redirects:
+        old_entity = redirect["old_entity"]
+        if old_entity in existing_old_entities:
+            print(f"old-entity {old_entity} already exists, skipping redirect")
+            continue
+        rows.append(
+            [
+                old_entity,
+                "301",
+                redirect["entity"],
+                redirect.get("notes"),
+                "",
+                today,
+                "",
+            ]
+        )
+        existing_old_entities.add(old_entity)
+
+    count = append_csv_rows(old_entity_file, rows)
+    if count:
+        print(f"Appended {count} duplicate redirect row(s) to {old_entity_file}")
 
 
 def retire_endpoints_in_csv(collection: str, retire_endpoints: list[str]) -> None:
@@ -433,6 +510,7 @@ def run_add_data_async(
     environment: str = DEFAULT_ENVIRONMENT,
     test_mode: bool = False,
     retire_endpoints: Optional[list[str]] = None,
+    entity_redirects: Optional[list[dict[str, str]]] = None,
 ) -> None:
     if not request_id.strip():
         fail("request_id is required")
@@ -458,6 +536,7 @@ def run_add_data_async(
     ensure_dir_exists(pipeline_dir)
 
     retire_endpoints = normalize_retire_endpoints(retire_endpoints or [])
+    entity_redirects = normalize_entity_redirects(entity_redirects or [])
 
     if test_mode:
         print("Test mode enabled; this creates a draft PR that must not be merged.")
@@ -468,6 +547,7 @@ def run_add_data_async(
         branch_name, pr_number, mode = resolve_branch(branch.strip(), collection)
 
     retire_endpoints_in_csv(collection, retire_endpoints)
+    append_entity_redirects(collection, entity_redirects)
     append_endpoint(response, collection)
     append_source(response, collection)
     append_lookup(response, collection)
@@ -573,6 +653,12 @@ def run_add_data_async(
     type=click.STRING,
     help="Endpoint strings to retire; pass multiple times or as comma-separated values",
 )
+@click.option(
+    "--entity-redirects",
+    default="",
+    type=click.STRING,
+    help="JSON array of duplicate entity redirects to append to old-entity.csv",
+)
 @click.option("--test/--no-test", "test_mode", default=False, help="Create a draft test PR that should not be merged")
 def main(
     request_id: str,
@@ -580,6 +666,7 @@ def main(
     triggered_by: str,
     environment: str,
     retire_endpoints: tuple[str, ...],
+    entity_redirects: str,
     test_mode: bool,
 ) -> None:
     print(f"Executing add_data.py with request_id={request_id}, branch={branch}, triggered_by={triggered_by}, "
@@ -595,6 +682,7 @@ def main(
         environment=environment,
         test_mode=test_mode,
         retire_endpoints=retire_endpoint_values,
+        entity_redirects=normalize_entity_redirects(entity_redirects),
     )
 
 

--- a/tests/unit/test_add_data.py
+++ b/tests/unit/test_add_data.py
@@ -228,13 +228,22 @@ def test_resolve_api_base_url_by_environment():
 def test_click_cli_wires_options_to_runner(monkeypatch):
     captured = {}
 
-    def fake_run(request_id, branch, triggered_by, environment, test_mode, retire_endpoints):
+    def fake_run(
+        request_id,
+        branch,
+        triggered_by,
+        environment,
+        test_mode,
+        retire_endpoints,
+        entity_redirects,
+    ):
         captured["request_id"] = request_id
         captured["branch"] = branch
         captured["triggered_by"] = triggered_by
         captured["environment"] = environment
         captured["test_mode"] = test_mode
         captured["retire_endpoints"] = retire_endpoints
+        captured["entity_redirects"] = entity_redirects
 
     monkeypatch.setattr(add_data, "run_add_data_async", fake_run)
     runner = CliRunner()
@@ -254,6 +263,8 @@ def test_click_cli_wires_options_to_runner(monkeypatch):
             "endpoint-a,endpoint-b",
             "--retire-endpoints",
             "endpoint-c",
+            "--entity-redirects",
+            '[{"old_entity":"10","entity":"20","notes":"duplicate"}]',
             "--test",
         ],
     )
@@ -266,7 +277,69 @@ def test_click_cli_wires_options_to_runner(monkeypatch):
         "environment": "development",
         "test_mode": True,
         "retire_endpoints": ["endpoint-a", "endpoint-b", "endpoint-c"],
+        "entity_redirects": [
+            {"old_entity": "10", "entity": "20", "notes": "duplicate"}
+        ],
     }
+
+
+def test_normalize_entity_redirects_parses_json():
+    redirects = add_data.normalize_entity_redirects(
+        '[{"old_entity":"10","entity":"20","notes":"duplicate"},'
+        '{"old_entity":"11","entity":"21"},'
+        '{"old_entity":"","entity":"30"},'
+        '"not-a-redirect"]'
+    )
+
+    assert redirects == [
+        {"old_entity": "10", "entity": "20", "notes": "duplicate"},
+        {"old_entity": "11", "entity": "21", "notes": ""},
+    ]
+
+
+def test_append_entity_redirects_creates_old_entity_csv(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    pipeline_dir = tmp_path / "pipeline" / "test-collection"
+    pipeline_dir.mkdir(parents=True)
+
+    add_data.append_entity_redirects(
+        "test-collection",
+        [{"old_entity": "10", "entity": "20", "notes": "duplicate"}],
+    )
+
+    old_entity_csv = pipeline_dir / "old-entity.csv"
+    rows = list(csv.reader(old_entity_csv.read_text(encoding="utf-8").splitlines()))
+    assert rows[0] == add_data.OLD_ENTITY_HEADER
+    assert rows[1][0:5] == ["10", "301", "20", "duplicate", ""]
+    assert rows[1][5]
+    assert rows[1][6] == ""
+
+
+def test_append_entity_redirects_skips_existing_old_entity(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    pipeline_dir = tmp_path / "pipeline" / "test-collection"
+    pipeline_dir.mkdir(parents=True)
+    old_entity_csv = pipeline_dir / "old-entity.csv"
+    old_entity_csv.write_text(
+        "old-entity,status,entity,notes,end-date,entry-date,start-date\r\n"
+        "10,301,20,existing,,2026-01-01,\r\n",
+        encoding="utf-8",
+    )
+
+    add_data.append_entity_redirects(
+        "test-collection",
+        [
+            {"old_entity": "10", "entity": "99", "notes": "skip"},
+            {"old_entity": "11", "entity": "21", "notes": "append"},
+        ],
+    )
+
+    body = old_entity_csv.read_text(encoding="utf-8")
+    assert body.count("\n") == 3
+    assert "10,301,99,skip" not in body
+    assert "11,301,21,append" in body
+
+
 def test_run_add_data_async_test_mode_creates_draft_pr(tmp_path, monkeypatch, capfd):
     monkeypatch.chdir(tmp_path)
     
@@ -436,6 +509,77 @@ def test_run_add_data_async_applies_retire_endpoints(tmp_path, monkeypatch):
     assert retired == {
         "collection": "test-collection",
         "endpoints": ["endpoint-old"],
+    }
+
+
+def test_run_add_data_async_applies_entity_redirects(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    collection_dir = tmp_path / "collection" / "test-collection"
+    pipeline_dir = tmp_path / "pipeline" / "test-collection"
+    collection_dir.mkdir(parents=True, exist_ok=True)
+    pipeline_dir.mkdir(parents=True, exist_ok=True)
+
+    response = {
+        "status": "COMPLETE",
+        "params": {
+            "collection": "test-collection",
+            "dataset": "test-dataset",
+            "organisation": "test-organisation",
+            "column_mapping": {},
+        },
+        "response": {
+            "data": {
+                "endpoint-summary": {},
+                "source-summary": {},
+                "pipeline-summary": {
+                    "new-entities": [],
+                    "entity-organisation": [],
+                },
+            }
+        },
+    }
+
+    captured = {"collection": "", "redirects": []}
+
+    def fake_append_redirects(collection, redirects):
+        captured["collection"] = collection
+        captured["redirects"] = redirects
+
+    def fake_run(cmd, text=True, capture_output=False, check=False):
+        if cmd[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+            return _CompletedProcess(returncode=0, stdout="main")
+        if cmd[:2] == ["git", "show-ref"]:
+            return _CompletedProcess(returncode=1)
+        if cmd[:3] == ["git", "diff", "--staged"]:
+            return _CompletedProcess(returncode=0)
+        return _CompletedProcess(returncode=0)
+
+    monkeypatch.setattr(add_data.subprocess, "run", fake_run)
+    monkeypatch.setattr(add_data, "fetch_request", lambda api_base_url, request_id: response)
+    monkeypatch.setattr(add_data, "write_summary", lambda *args, **kwargs: None)
+    monkeypatch.setattr(add_data, "append_endpoint", lambda *args, **kwargs: None)
+    monkeypatch.setattr(add_data, "append_source", lambda *args, **kwargs: None)
+    monkeypatch.setattr(add_data, "retire_endpoints_in_csv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(add_data, "append_entity_redirects", fake_append_redirects)
+    monkeypatch.setattr(add_data, "append_lookup", lambda *args, **kwargs: None)
+    monkeypatch.setattr(add_data, "append_column", lambda *args, **kwargs: None)
+    monkeypatch.setattr(add_data, "append_entity_organisation", lambda *args, **kwargs: None)
+
+    add_data.run_add_data_async(
+        request_id="req-123",
+        branch="",
+        triggered_by="bot",
+        test_mode=False,
+        environment="development",
+        entity_redirects='[{"old_entity":"10","entity":"20","notes":"duplicate"}]',
+    )
+
+    assert captured == {
+        "collection": "test-collection",
+        "redirects": [
+            {"old_entity": "10", "entity": "20", "notes": "duplicate"}
+        ],
     }
 
 


### PR DESCRIPTION
## Data Template

**Ticket**
- Link: Ticket #2660
- 
**Type**
- [ ] New data
- [ ] Data monitoring
- [ ] Data fix


**Expected outcome (if relevant):**
- [ ] New endpoint & source
- [ ] New lookups
- [ ] Extra endpoint config (e.g. column, concat)
- [ ] Retired old endpoint & source
- [ ] Retired old entities
- [ ] Retired old resource

**Additional information:**
- Adds optional `entity_redirects` support to the async add-data workflow.
- `entity_redirects` is passed as JSON and appended to `pipeline/<collection>/old-entity.csv` as `301` redirects.
- Existing `old-entity` values are skipped to avoid duplicate redirect rows.
- Adds unit test coverage for CLI wiring, JSON normalisation, old-entity CSV creation, duplicate skipping, and async runner integration.
- 
**Requester's checklist:**
- [ ] Have checked if any old endpoints to retire
- [ ] Have validated endpoint (with check or endpoint checker)
- [ ] Have checked expected number of lookups
- [ ] Have checked for any geo duplicates (if CA data)
- [ ] Have updated entity-organisation.csv (if CA data)

**Reviewer's checklist:**
- [ ] Expected checks have been completed by PR requester
- [ ] Correct date format used in config files (YYYY-mm-dd)
- [ ] Number of new lookups is as expected from source data
- [ ] Spot checked that newly assigned entity numbers aren’t in use