### PR TITLE
with new overlap flag, entity min and entity max may be empty

### DIFF
--- a/bin/add_data.py
+++ b/bin/add_data.py
@@ -382,6 +382,13 @@ def append_entity_organisation(response: dict, collection: str) -> None:
 
     rows = []
     for entry in entries:
+        if entry.get("entity-minimum") is None or entry.get("entity-maximum") is None:
+            print(
+                "Skipping entity-organisation entry with no entity-minimum/"
+                f"entity-maximum (overlap={entry.get('overlap')}, "
+                f"error={entry.get('error')})"
+            )
+            continue
         rows.append(
             [
                 entry.get("dataset"),
@@ -390,6 +397,10 @@ def append_entity_organisation(response: dict, collection: str) -> None:
                 entry.get("organisation"),
             ]
         )
+
+    if not rows:
+        print("No valid entity-organisation entries to add, skipping")
+        return
 
     count = append_csv_rows(entity_org_file, rows)
 

--- a/tests/unit/test_add_data.py
+++ b/tests/unit/test_add_data.py
@@ -130,6 +130,96 @@ def test_append_source_skips_when_documentation_url_exists(tmp_path, monkeypatch
     assert source_file.read_text(encoding="utf-8") == original
 
 
+def _entity_organisation_response(entries, authoritative=True):
+    return {
+        "params": {"authoritative": authoritative},
+        "response": {
+            "data": {
+                "pipeline-summary": {
+                    "entity-organisation": entries,
+                }
+            }
+        },
+    }
+
+
+def test_append_entity_organisation_writes_new_row(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    entity_org_file = tmp_path / "pipeline/test-collection/entity-organisation.csv"
+    _write_csv(entity_org_file, ["dataset", "entity-minimum", "entity-maximum", "organisation"])
+
+    response = _entity_organisation_response(
+        [
+            {
+                "dataset": "nature-improvement-area",
+                "entity-minimum": 10100002,
+                "entity-maximum": 10100005,
+                "organisation": "government-organisation:PB202",
+                "overlap": False,
+                "error": False,
+            }
+        ]
+    )
+
+    add_data.append_entity_organisation(response, "test-collection")
+
+    rows = list(csv.reader(entity_org_file.read_text(encoding="utf-8").splitlines()))
+    assert rows[1] == [
+        "nature-improvement-area",
+        "10100002",
+        "10100005",
+        "government-organisation:PB202",
+    ]
+
+
+def test_append_entity_organisation_skips_entry_missing_range(tmp_path, monkeypatch):
+    """overlap/error entries have no entity-minimum/maximum - must not be written"""
+    monkeypatch.chdir(tmp_path)
+    entity_org_file = tmp_path / "pipeline/test-collection/entity-organisation.csv"
+    _write_csv(entity_org_file, ["dataset", "entity-minimum", "entity-maximum", "organisation"])
+    original = entity_org_file.read_text(encoding="utf-8")
+
+    response = _entity_organisation_response(
+        [
+            {
+                "dataset": "nature-improvement-area",
+                "organisation": "government-organisation:PB202",
+                "overlap": True,
+                "error": False,
+            }
+        ]
+    )
+
+    add_data.append_entity_organisation(response, "test-collection")
+
+    assert entity_org_file.read_text(encoding="utf-8") == original
+
+
+def test_append_entity_organisation_skips_when_not_authoritative(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    entity_org_file = tmp_path / "pipeline/test-collection/entity-organisation.csv"
+    _write_csv(entity_org_file, ["dataset", "entity-minimum", "entity-maximum", "organisation"])
+    original = entity_org_file.read_text(encoding="utf-8")
+
+    response = _entity_organisation_response(
+        [
+            {
+                "dataset": "nature-improvement-area",
+                "entity-minimum": 10100002,
+                "entity-maximum": 10100005,
+                "organisation": "government-organisation:PB202",
+                "overlap": False,
+                "error": False,
+            }
+        ],
+        authoritative=False,
+    )
+
+    add_data.append_entity_organisation(response, "test-collection")
+
+    assert entity_org_file.read_text(encoding="utf-8") == original
+
+
 def test_retire_endpoints_in_csv_updates_source_and_endpoint(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 


### PR DESCRIPTION
## Data Template

**Ticket**
- Link: 

**Type**
- [ ] New data
- [ ] Data monitoring
- [ ] Data fix

**Data updated (list organisation and dataset):**
- Dataset:

**Expected outcome (if relevant):**
- [ ] New endpoint & source
- [ ] New lookups
- [ ] Extra endpoint config (e.g. column, concat)
- [ ] Retired old endpoint & source
- [ ] Retired old entities
- [ ] Retired old resource

**Additional information:**
- Any other relevant details or considerations.

**Requester's checklist:**
- [ ] Have checked if any old endpoints to retire
- [ ] Have validated endpoint (with check or endpoint checker)
- [ ] Have checked expected number of lookups
- [ ] Have checked for any geo duplicates (if CA data)
- [ ] Have updated entity-organisation.csv (if CA data)

**Reviewer's checklist:**
- [ ] Expected checks have been completed by PR requester
- [ ] Correct date format used in config files (YYYY-mm-dd)
- [ ] Number of new lookups is as expected from source data
- [ ] Spot checked that newly assigned entity numbers aren’t in use
