### PR TITLE
add lookup-rule and blank lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ performance/
 /makerules/
 
 # ignore specific files
-pipeline/title-boundary/lookup.csv
 /*.csv
 
 

--- a/pipeline/title-boundary/lookup-rule.csv
+++ b/pipeline/title-boundary/lookup-rule.csv
@@ -1,0 +1,2 @@
+prefix,dataset,organisation,resource,offset,entity-minimum,entity-maximum,entry-date,start-date,end-date
+title-boundary,title-boundary,,,12000000000,12000000000,12999999999,,,

--- a/pipeline/title-boundary/lookup.csv
+++ b/pipeline/title-boundary/lookup.csv
@@ -1,0 +1,1 @@
+prefix,resource,endpoint,entry-number,organisation,reference,entity,entry-date,start-date,end-date


### PR DESCRIPTION
## Description
Switch title-boundary to rule-based entity numbering:
- add `pipeline/title-boundary/lookup-rule.csv` — one rule: `entity = reference + 12,000,000,000`, bounded to title-boundary's entity range `[12000000000, 12999999999]`
- add a header-only `pipeline/title-boundary/lookup.csv` — on publish this overwrites the S3 copy (184 MB, 2.6M rows), so entity assignment falls through to the rule

## Why
Title-boundary's per-record lookup.csv (2.6M rows) doesn't scale and its entity numbers are non-deterministic (assigned by load order in the original one-time load — not reproducible).
The rule gives deterministic numbers (`reference + offset`) with no stored state, which the pyspark reprocessing of title-boundary needs.

The mechanism (digital-land-python #572) and the config download (makerules) are already merged; this PR is the per-collection config that enables it for title-boundary only.

## Consequences
- **All ~2.6M title-boundary entities are renumbered** on next pipeline run (this will probably not be for a while in PROD - title-boundary is currently dev and staging only). Old numbering was load-order — no rule can reproduce it. Old/new ranges don't overlap, so stale old IDs never point at a different polygon. Old→new mapping = `reference + 12e9`; the original lookup.csv is archived at `s3://{env}-collection-data/archive/old-title-boundary-lookup.csv` (staging + production).
- 228 duplicate references (same polygon loaded twice) collapse to one entity each — a small data-quality fix.
- Renumbering only takes effect when the title-boundary pipeline actually runs: staging on its next scheduled run (our practice run); production only when we deliberately run it.

## How I know this is safe for the short-term
This can only affect title-boundary. 
Dags for title-boundary or new-title-boundary are not available in PROD airflow, they are removed using the environment field in the spec, so they will not get run by accident. The data will stay as it (with the current entity numbers) until we run in PROD - which we wont do until its properly tested and working in Staging. There will need to be another PR to change that on the spec repo.
This will copy over the lookup.csv in the s3 buckets for each env, but that is why we stored copies in the archive folder in s3 for each of prod and staging.


## Verification (post-merge, staging)
- config publish overwrites S3 lookup.csv (size drops 184 MB → ~100 B)
- title-boundary run: rule loads (no "optional lookup-rule.csv not present — skipping" line), entities = `reference + 12,000,000,000`, all in range
- lookup.csv does NOT repopulate with new rows

[Link to relevant issue](https://github.com/digital-land/config/issues/2750)


**Type**
- [ ] New data
- [ ] Data monitoring
- [ ] Data fix

**Data updated (list organisation and dataset):**
- Dataset:

**Expected outcome (if relevant):**
- [ ] New endpoint & source
- [ ] New lookups
- [ ] Extra endpoint config (e.g. column, concat)
- [ ] Retired old endpoint & source
- [ ] Retired old entities
- [ ] Retired old resource

**Additional information:**
- Any other relevant details or considerations.

**Requester's checklist:**
- [ ] Have checked if any old endpoints to retire
- [ ] Have validated endpoint (with check or endpoint checker)
- [ ] Have checked expected number of lookups
- [ ] Have checked for any geo duplicates (if CA data)
- [ ] Have updated entity-organisation.csv (if CA data)

**Reviewer's checklist:**
- [ ] Expected checks have been completed by PR requester
- [ ] Correct date format used in config files (YYYY-mm-dd)
- [ ] Number of new lookups is as expected from source data
- [ ] Spot checked that newly assigned entity numbers aren’t in use
