### PR TITLE
refactor: Remove entity redirects handling from async data processing

### DIFF
--- a/.github/workflows/add-data-async-script.yml
+++ b/.github/workflows/add-data-async-script.yml
@@ -30,10 +30,6 @@ on:
         description: 'Comma-separated endpoint strings to retire (optional)'
         required: false
         type: string
-      entity_redirects:
-        description: 'JSON duplicate entity redirects to append to old-entity.csv (optional)'
-        required: false
-        type: string
       test:
         description: 'Run in test mode (creates draft PR)'
         required: false
@@ -76,7 +72,6 @@ jobs:
           TRIGGERED_BY: ${{ github.event.client_payload.triggered_by || github.event.inputs.triggered_by }}
           ENVIRONMENT: ${{ github.event.client_payload.environment || github.event.inputs.environment || 'staging' }}
           RETIRE_ENDPOINTS: ${{ github.event.client_payload.retire_endpoints || github.event.inputs.retire_endpoints }}
-          ENTITY_REDIRECTS: ${{ github.event.client_payload.entity_redirects || github.event.inputs.entity_redirects }}
           TEST_MODE: ${{ github.event.inputs.test }}
         run: |
           ARGS=(
@@ -92,10 +87,6 @@ jobs:
 
           if [ -n "$RETIRE_ENDPOINTS" ]; then
             ARGS+=(--retire-endpoints "$RETIRE_ENDPOINTS")
-          fi
-
-          if [ -n "$ENTITY_REDIRECTS" ]; then
-            ARGS+=(--entity-redirects "$ENTITY_REDIRECTS")
           fi
 
           if [ "$TEST_MODE" = "true" ]; then

--- a/bin/add_data.py
+++ b/bin/add_data.py
@@ -122,42 +122,19 @@ def normalize_retire_endpoints(value: object) -> list[str]:
     return []
 
 
-def normalize_entity_redirects(value: object) -> list[dict[str, str]]:
-    if value is None:
-        return []
-    if isinstance(value, str):
-        if not value.strip():
-            return []
-        try:
-            value = json.loads(value)
-        except json.JSONDecodeError as exc:
-            fail(f"Failed to parse entity redirects JSON: {exc}")
-    if not isinstance(value, list):
-        return []
+def append_old_entity(response: dict, collection: str) -> None:
+    entries = (
+        response.get("response", {})
+        .get("data", {})
+        .get("pipeline-summary", {})
+        .get("old-entity")
+        or []
+    )
 
-    redirects = []
-    for item in value:
-        if not isinstance(item, dict):
-            continue
-        old_entity = str(item.get("old_entity", "") or "").strip()
-        entity = str(item.get("entity", "") or "").strip()
-        if not old_entity or not entity:
-            continue
-        redirects.append(
-            {
-                "old_entity": old_entity,
-                "entity": entity,
-                "notes": item.get("notes", ""),
-            }
-        )
-    return redirects
-
-
-def append_entity_redirects(collection: str, entity_redirects: list[dict[str, str]]) -> None:
-    if not entity_redirects:
+    if not entries:
+        print("No old-entity entries found, skipping")
         return
 
-    today = datetime.now().strftime("%Y-%m-%d")
     old_entity_file = Path("pipeline") / collection / "old-entity.csv"
     if old_entity_file.exists():
         frame = pd.read_csv(old_entity_file, dtype=str, keep_default_na=False)
@@ -167,27 +144,35 @@ def append_entity_redirects(collection: str, entity_redirects: list[dict[str, st
         existing_old_entities = set()
 
     rows = []
-    for redirect in entity_redirects:
-        old_entity = redirect["old_entity"]
+    for entry in entries:
+        old_entity = entry.get("old-entity")
+        status = entry.get("status")
+        if old_entity is None or status is None:
+            print(
+                "Skipping old-entity entry with no old-entity/status "
+                f"(old-entity={old_entity}, status={status})"
+            )
+            continue
+        old_entity = str(old_entity)
         if old_entity in existing_old_entities:
-            print(f"old-entity {old_entity} already exists, skipping redirect")
+            print(f"old-entity {old_entity} already exists, skipping")
             continue
         rows.append(
             [
                 old_entity,
-                "301",
-                redirect["entity"],
-                redirect.get("notes"),
-                "",
-                today,
-                "",
+                status,
+                entry.get("entity"),
+                entry.get("notes"),
+                entry.get("end-date"),
+                entry.get("entry-date"),
+                entry.get("start-date"),
             ]
         )
         existing_old_entities.add(old_entity)
 
     count = append_csv_rows(old_entity_file, rows)
     if count:
-        print(f"Appended {count} duplicate redirect row(s) to {old_entity_file}")
+        print(f"Appended {count} row(s) to {old_entity_file}")
 
 
 def retire_endpoints_in_csv(collection: str, retire_endpoints: list[str]) -> None:
@@ -521,7 +506,6 @@ def run_add_data_async(
     environment: str = DEFAULT_ENVIRONMENT,
     test_mode: bool = False,
     retire_endpoints: Optional[list[str]] = None,
-    entity_redirects: Optional[list[dict[str, str]]] = None,
 ) -> None:
     if not request_id.strip():
         fail("request_id is required")
@@ -547,7 +531,6 @@ def run_add_data_async(
     ensure_dir_exists(pipeline_dir)
 
     retire_endpoints = normalize_retire_endpoints(retire_endpoints or [])
-    entity_redirects = normalize_entity_redirects(entity_redirects or [])
 
     if test_mode:
         print("Test mode enabled; this creates a draft PR that must not be merged.")
@@ -558,7 +541,7 @@ def run_add_data_async(
         branch_name, pr_number, mode = resolve_branch(branch.strip(), collection)
 
     retire_endpoints_in_csv(collection, retire_endpoints)
-    append_entity_redirects(collection, entity_redirects)
+    append_old_entity(response, collection)
     append_endpoint(response, collection)
     append_source(response, collection)
     append_lookup(response, collection)
@@ -664,12 +647,6 @@ def run_add_data_async(
     type=click.STRING,
     help="Endpoint strings to retire; pass multiple times or as comma-separated values",
 )
-@click.option(
-    "--entity-redirects",
-    default="",
-    type=click.STRING,
-    help="JSON array of duplicate entity redirects to append to old-entity.csv",
-)
 @click.option("--test/--no-test", "test_mode", default=False, help="Create a draft test PR that should not be merged")
 def main(
     request_id: str,
@@ -677,7 +654,6 @@ def main(
     triggered_by: str,
     environment: str,
     retire_endpoints: tuple[str, ...],
-    entity_redirects: str,
     test_mode: bool,
 ) -> None:
     print(f"Executing add_data.py with request_id={request_id}, branch={branch}, triggered_by={triggered_by}, "
@@ -693,7 +669,6 @@ def main(
         environment=environment,
         test_mode=test_mode,
         retire_endpoints=retire_endpoint_values,
-        entity_redirects=normalize_entity_redirects(entity_redirects),
     )
 
 

--- a/tests/integration/test_add_data.py
+++ b/tests/integration/test_add_data.py
@@ -115,6 +115,17 @@ def test_add_data_cli_creates_expected_files(tmp_path, monkeypatch):
                             "organisation": "test-organisation",
                         }
                     ],
+                    "old-entity": [
+                        {
+                            "old-entity": "100",
+                            "status": "301",
+                            "entity": "101",
+                            "notes": "duplicate",
+                            "end-date": "",
+                            "entry-date": "2026-04-24",
+                            "start-date": "",
+                        }
+                    ],
                 },
             }
         },
@@ -154,6 +165,7 @@ def test_add_data_cli_creates_expected_files(tmp_path, monkeypatch):
     lookup_rows = list(csv.reader((pipeline_dir / "lookup.csv").read_text(encoding="utf-8").splitlines()))
     column_rows = list(csv.reader((pipeline_dir / "column.csv").read_text(encoding="utf-8").splitlines()))
     entity_org_rows = list(csv.reader((pipeline_dir / "entity-organisation.csv").read_text(encoding="utf-8").splitlines()))
+    old_entity_rows = list(csv.reader((pipeline_dir / "old-entity.csv").read_text(encoding="utf-8").splitlines()))
 
     assert endpoint_rows[1] == [
         "endpoint-hash",
@@ -210,6 +222,8 @@ def test_add_data_cli_creates_expected_files(tmp_path, monkeypatch):
         "2026-04-24",
     ]
     assert entity_org_rows[1] == ["test-dataset", "101", "101", "test-organisation"]
+    assert old_entity_rows[0] == add_data.OLD_ENTITY_HEADER
+    assert old_entity_rows[1] == ["100", "301", "101", "duplicate", "", "2026-04-24", ""]
 
     summary = (tmp_path / "summary.md").read_text(encoding="utf-8")
     assert "test-collection updated via async request req-123" in summary

--- a/tests/unit/test_add_data.py
+++ b/tests/unit/test_add_data.py
@@ -143,6 +143,18 @@ def _entity_organisation_response(entries, authoritative=True):
     }
 
 
+def _old_entity_response(entries):
+    return {
+        "response": {
+            "data": {
+                "pipeline-summary": {
+                    "old-entity": entries,
+                }
+            }
+        },
+    }
+
+
 def test_append_entity_organisation_writes_new_row(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     entity_org_file = tmp_path / "pipeline/test-collection/entity-organisation.csv"
@@ -218,6 +230,92 @@ def test_append_entity_organisation_skips_when_not_authoritative(tmp_path, monke
     add_data.append_entity_organisation(response, "test-collection")
 
     assert entity_org_file.read_text(encoding="utf-8") == original
+
+
+def test_append_old_entity_writes_new_row(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    old_entity_file = tmp_path / "pipeline/test-collection/old-entity.csv"
+    _write_csv(old_entity_file, add_data.OLD_ENTITY_HEADER)
+
+    response = _old_entity_response(
+        [
+            {
+                "old-entity": "10",
+                "status": "301",
+                "entity": "20",
+                "notes": "duplicate",
+                "end-date": "",
+                "entry-date": "2026-04-24",
+                "start-date": "",
+            }
+        ]
+    )
+
+    add_data.append_old_entity(response, "test-collection")
+
+    rows = list(csv.reader(old_entity_file.read_text(encoding="utf-8").splitlines()))
+    assert rows[1] == ["10", "301", "20", "duplicate", "", "2026-04-24", ""]
+
+
+def test_append_old_entity_skips_existing_old_entity(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    old_entity_file = tmp_path / "pipeline/test-collection/old-entity.csv"
+    _write_csv(
+        old_entity_file,
+        add_data.OLD_ENTITY_HEADER,
+        [["10", "301", "20", "existing", "", "2026-01-01", ""]],
+    )
+
+    response = _old_entity_response(
+        [
+            {
+                "old-entity": "10",
+                "status": "301",
+                "entity": "99",
+                "notes": "skip",
+                "end-date": "",
+                "entry-date": "2026-04-24",
+                "start-date": "",
+            },
+            {
+                "old-entity": "11",
+                "status": "301",
+                "entity": "21",
+                "notes": "append",
+                "end-date": "",
+                "entry-date": "2026-04-24",
+                "start-date": "",
+            },
+        ]
+    )
+
+    add_data.append_old_entity(response, "test-collection")
+
+    body = old_entity_file.read_text(encoding="utf-8")
+    assert body.count("\n") == 3
+    assert "10,301,99,skip" not in body
+    assert "11,301,21,append,,2026-04-24," in body
+
+
+def test_append_old_entity_skips_entry_missing_old_entity_or_status(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    old_entity_file = tmp_path / "pipeline/test-collection/old-entity.csv"
+    _write_csv(old_entity_file, add_data.OLD_ENTITY_HEADER)
+    original = old_entity_file.read_text(encoding="utf-8")
+
+    response = _old_entity_response(
+        [
+            {
+                "old-entity": "10",
+                "entity": "20",
+                "notes": "missing status",
+            }
+        ]
+    )
+
+    add_data.append_old_entity(response, "test-collection")
+
+    assert old_entity_file.read_text(encoding="utf-8") == original
 
 
 def test_retire_endpoints_in_csv_updates_source_and_endpoint(tmp_path, monkeypatch):
@@ -325,7 +423,6 @@ def test_click_cli_wires_options_to_runner(monkeypatch):
         environment,
         test_mode,
         retire_endpoints,
-        entity_redirects,
     ):
         captured["request_id"] = request_id
         captured["branch"] = branch
@@ -333,7 +430,6 @@ def test_click_cli_wires_options_to_runner(monkeypatch):
         captured["environment"] = environment
         captured["test_mode"] = test_mode
         captured["retire_endpoints"] = retire_endpoints
-        captured["entity_redirects"] = entity_redirects
 
     monkeypatch.setattr(add_data, "run_add_data_async", fake_run)
     runner = CliRunner()
@@ -353,8 +449,6 @@ def test_click_cli_wires_options_to_runner(monkeypatch):
             "endpoint-a,endpoint-b",
             "--retire-endpoints",
             "endpoint-c",
-            "--entity-redirects",
-            '[{"old_entity":"10","entity":"20","notes":"duplicate"}]',
             "--test",
         ],
     )
@@ -367,67 +461,7 @@ def test_click_cli_wires_options_to_runner(monkeypatch):
         "environment": "development",
         "test_mode": True,
         "retire_endpoints": ["endpoint-a", "endpoint-b", "endpoint-c"],
-        "entity_redirects": [
-            {"old_entity": "10", "entity": "20", "notes": "duplicate"}
-        ],
     }
-
-
-def test_normalize_entity_redirects_parses_json():
-    redirects = add_data.normalize_entity_redirects(
-        '[{"old_entity":"10","entity":"20","notes":"duplicate"},'
-        '{"old_entity":"11","entity":"21"},'
-        '{"old_entity":"","entity":"30"},'
-        '"not-a-redirect"]'
-    )
-
-    assert redirects == [
-        {"old_entity": "10", "entity": "20", "notes": "duplicate"},
-        {"old_entity": "11", "entity": "21", "notes": ""},
-    ]
-
-
-def test_append_entity_redirects_creates_old_entity_csv(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    pipeline_dir = tmp_path / "pipeline" / "test-collection"
-    pipeline_dir.mkdir(parents=True)
-
-    add_data.append_entity_redirects(
-        "test-collection",
-        [{"old_entity": "10", "entity": "20", "notes": "duplicate"}],
-    )
-
-    old_entity_csv = pipeline_dir / "old-entity.csv"
-    rows = list(csv.reader(old_entity_csv.read_text(encoding="utf-8").splitlines()))
-    assert rows[0] == add_data.OLD_ENTITY_HEADER
-    assert rows[1][0:5] == ["10", "301", "20", "duplicate", ""]
-    assert rows[1][5]
-    assert rows[1][6] == ""
-
-
-def test_append_entity_redirects_skips_existing_old_entity(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    pipeline_dir = tmp_path / "pipeline" / "test-collection"
-    pipeline_dir.mkdir(parents=True)
-    old_entity_csv = pipeline_dir / "old-entity.csv"
-    old_entity_csv.write_text(
-        "old-entity,status,entity,notes,end-date,entry-date,start-date\r\n"
-        "10,301,20,existing,,2026-01-01,\r\n",
-        encoding="utf-8",
-    )
-
-    add_data.append_entity_redirects(
-        "test-collection",
-        [
-            {"old_entity": "10", "entity": "99", "notes": "skip"},
-            {"old_entity": "11", "entity": "21", "notes": "append"},
-        ],
-    )
-
-    body = old_entity_csv.read_text(encoding="utf-8")
-    assert body.count("\n") == 3
-    assert "10,301,99,skip" not in body
-    assert "11,301,21,append" in body
 
 
 def test_run_add_data_async_test_mode_creates_draft_pr(tmp_path, monkeypatch, capfd):
@@ -602,7 +636,7 @@ def test_run_add_data_async_applies_retire_endpoints(tmp_path, monkeypatch):
     }
 
 
-def test_run_add_data_async_applies_entity_redirects(tmp_path, monkeypatch):
+def test_run_add_data_async_appends_old_entity_from_response(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     collection_dir = tmp_path / "collection" / "test-collection"
@@ -625,16 +659,27 @@ def test_run_add_data_async_applies_entity_redirects(tmp_path, monkeypatch):
                 "pipeline-summary": {
                     "new-entities": [],
                     "entity-organisation": [],
+                    "old-entity": [
+                        {
+                            "old-entity": "10",
+                            "status": "301",
+                            "entity": "20",
+                            "notes": "duplicate",
+                            "end-date": "",
+                            "entry-date": "2026-04-24",
+                            "start-date": "",
+                        }
+                    ],
                 },
             }
         },
     }
 
-    captured = {"collection": "", "redirects": []}
+    captured = {"collection": "", "response": None}
 
-    def fake_append_redirects(collection, redirects):
+    def fake_append_old_entity(response_arg, collection):
         captured["collection"] = collection
-        captured["redirects"] = redirects
+        captured["response"] = response_arg
 
     def fake_run(cmd, text=True, capture_output=False, check=False):
         if cmd[:3] == ["git", "rev-parse", "--abbrev-ref"]:
@@ -651,7 +696,7 @@ def test_run_add_data_async_applies_entity_redirects(tmp_path, monkeypatch):
     monkeypatch.setattr(add_data, "append_endpoint", lambda *args, **kwargs: None)
     monkeypatch.setattr(add_data, "append_source", lambda *args, **kwargs: None)
     monkeypatch.setattr(add_data, "retire_endpoints_in_csv", lambda *args, **kwargs: None)
-    monkeypatch.setattr(add_data, "append_entity_redirects", fake_append_redirects)
+    monkeypatch.setattr(add_data, "append_old_entity", fake_append_old_entity)
     monkeypatch.setattr(add_data, "append_lookup", lambda *args, **kwargs: None)
     monkeypatch.setattr(add_data, "append_column", lambda *args, **kwargs: None)
     monkeypatch.setattr(add_data, "append_entity_organisation", lambda *args, **kwargs: None)
@@ -662,15 +707,9 @@ def test_run_add_data_async_applies_entity_redirects(tmp_path, monkeypatch):
         triggered_by="bot",
         test_mode=False,
         environment="development",
-        entity_redirects='[{"old_entity":"10","entity":"20","notes":"duplicate"}]',
     )
 
-    assert captured == {
-        "collection": "test-collection",
-        "redirects": [
-            {"old_entity": "10", "entity": "20", "notes": "duplicate"}
-        ],
-    }
+    assert captured == {"collection": "test-collection", "response": response}
 
 
 def test_run_command_reports_missing_binary(monkeypatch):


### PR DESCRIPTION
## Data Template

**Ticket**
- Link: 

**Type**
- [ ] New data
- [ ] Data monitoring
- [x] Data fix

**Data updated (list organisation and dataset):**
- Dataset: N/A - updates add-data async workflow handling for `old-entity.csv`

**Expected outcome (if relevant):**
- [ ] New endpoint & source
- [ ] New lookups
- [ ] Extra endpoint config (e.g. column, concat)
- [ ] Retired old endpoint & source
- [x] Retired old entities
- [ ] Retired old resource

**Additional information:**
- `old-entity.csv` rows are now read from `response.response.data.pipeline-summary.old-entity`, matching the existing `entity-organisation` response-driven pattern.
- Removed the separate `entity_redirects` workflow/CLI payload.
- Existing `old-entity` values are skipped to avoid duplicate rows.
- Validation: `.venv/bin/pytest tests/unit/test_add_data.py tests/integration/test_add_data.py` passed.

**Requester's checklist:**
- [ ] Have checked if any old endpoints to retire
- [ ] Have validated endpoint (with check or endpoint checker)
- [ ] Have checked expected number of lookups
- [ ] Have checked for any geo duplicates (if CA data)
- [ ] Have updated entity-organisation.csv (if CA data)

**Reviewer's checklist:**
- [ ] Expected checks have been completed by PR requester
- [ ] Correct date format used in config files (YYYY-mm-dd)
- [ ] Number of new lookups is as expected from source data
- [ ] Spot checked that newly assigned entity numbers aren’t in use