### PR TITLE
Block config-manager-update auto-merge on failing tests

### DIFF
--- a/.github/workflows/auto-merge-config-manager.yml
+++ b/.github/workflows/auto-merge-config-manager.yml
@@ -41,8 +41,24 @@ jobs:
             echo "Found PR #$PR_NUMBER"
           fi
 
-      - name: Approve PR
+      - name: Check latest test status
+        id: check-tests
         if: steps.check-pr.outputs.pr_exists == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          FAILING=$(gh pr checks ${{ steps.check-pr.outputs.pr_number }} --json name,bucket \
+            --jq '[.[] | select(.bucket != "pass" and .bucket != "skipping")] | length') || FAILING=1
+
+          if [ "$FAILING" -gt 0 ]; then
+            echo "tests_passed=false" >> $GITHUB_OUTPUT
+            echo "One or more checks on config-manager-update are failing or still pending — not merging."
+          else
+            echo "tests_passed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Approve PR
+        if: steps.check-pr.outputs.pr_exists == 'true' && steps.check-tests.outputs.tests_passed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -51,7 +67,7 @@ jobs:
             --body "Auto-approved by workflow"
 
       - name: Merge PR with squash
-        if: steps.check-pr.outputs.pr_exists == 'true'
+        if: steps.check-pr.outputs.pr_exists == 'true' && steps.check-tests.outputs.tests_passed == 'true'
         id: merge
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -62,7 +78,7 @@ jobs:
             --admin && echo "merge_success=true" >> $GITHUB_OUTPUT || echo "merge_success=false" >> $GITHUB_OUTPUT
 
       - name: Notify Slack on merge failure
-        if: steps.check-pr.outputs.pr_exists == 'true' && steps.merge.outputs.merge_success == 'false'
+        if: steps.check-pr.outputs.pr_exists == 'true' && steps.check-tests.outputs.tests_passed == 'true' && steps.merge.outputs.merge_success == 'false'
         uses: digital-land/github-action-slack-notify-build@main
         with:
           channel: planning-data-alerts

--- a/.github/workflows/config-evening-pipeline.yml
+++ b/.github/workflows/config-evening-pipeline.yml
@@ -104,8 +104,24 @@ jobs:
             echo "Found PR #$PR_NUMBER"
           fi
 
+      - name: Check latest test status
+        id: check-tests
+        if: steps.check-pr.outputs.pr_exists == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          FAILING=$(gh pr checks ${{ steps.check-pr.outputs.pr_number }} --json name,bucket \
+            --jq '[.[] | select(.bucket != "pass" and .bucket != "skipping")] | length') || FAILING=1
+
+          if [ "$FAILING" -gt 0 ]; then
+            echo "tests_passed=false" >> $GITHUB_OUTPUT
+            echo "One or more checks on config-manager-update are failing or still pending — not merging."
+          else
+            echo "tests_passed=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Approve PR
-        if: steps.check-pr.outputs.pr_exists == 'true' && env.WRITES_ENABLED == 'true'
+        if: steps.check-pr.outputs.pr_exists == 'true' && steps.check-tests.outputs.tests_passed == 'true' && env.WRITES_ENABLED == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -114,7 +130,7 @@ jobs:
             --body "Auto-approved by workflow"
 
       - name: Merge PR with squash
-        if: steps.check-pr.outputs.pr_exists == 'true' && env.WRITES_ENABLED == 'true'
+        if: steps.check-pr.outputs.pr_exists == 'true' && steps.check-tests.outputs.tests_passed == 'true' && env.WRITES_ENABLED == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -123,10 +139,16 @@ jobs:
             --delete-branch \
             --admin
 
+      - name: Fail job if merge was skipped due to failing tests
+        if: steps.check-pr.outputs.pr_exists == 'true' && steps.check-tests.outputs.tests_passed == 'false' && env.WRITES_ENABLED == 'true'
+        run: |
+          echo "::error::config-manager-update has failing or pending checks — not merging into main. PR: https://github.com/${{ github.repository }}/pull/${{ steps.check-pr.outputs.pr_number }}"
+          exit 1
+
       - name: Dry run — skipping PR merge
         if: steps.check-pr.outputs.pr_exists == 'true' && env.WRITES_ENABLED != 'true'
         run: |
-          echo "Dry run: PR #${{ steps.check-pr.outputs.pr_number }} would be approved and squash-merged here."
+          echo "Dry run: PR #${{ steps.check-pr.outputs.pr_number }} would be approved and squash-merged here (tests_passed=${{ steps.check-tests.outputs.tests_passed }})."
 
   # 2. Batch assign unknown entities. The script self-commits & pushes to main per batch.
   #    Only runs Mon–Fri

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ on:
   push:
   workflow_dispatch:
 
+env:
+  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
 jobs:
   build:
 
@@ -29,3 +32,11 @@ jobs:
       run: make test
       env:
         COLLECTION: dummy
+
+    - name: Notify slack failure
+      if: failure()
+      uses: digital-land/github-action-slack-notify-build@main
+      with:
+        channel: planning-data-alerts
+        status: FAILED
+        color: danger


### PR DESCRIPTION
## Data Template

**Type**
- [ ] New data
- [X] Data monitoring
- [ ] Data fix

## Summary

Adds Slack alerting for config test failures, and stops `config-manager-update` from being auto-merged into `main` overnight when its tests are failing.

- **`test.yml`**: post a Slack alert to `planning-data-alerts` when the push-triggered config test fails (any branch), matching the pattern already used by other workflows in this repo.
- **`config-evening-pipeline.yml`**: the nightly `merge` job now checks the latest test status on the `config-manager-update → main` PR before approving/merging. If any check is failing or still pending, the job fails explicitly (`::error::` + `exit 1`) instead of merging — this is picked up by the pipeline's existing consolidated `notify` job, so it shows up in the single end-of-run Slack summary alongside the other stage results, and the rest of the pipeline (`batch-assign`, `deduplicate`, `standardise`, `detect-environments`, `upload-s3`) continues to run as normal (`if: !cancelled()`), operating against `main` as it stood before the blocked merge.
- **`auto-merge-config-manager.yml`** (manual debugging workflow): same test-status gate applied, so it can't be used to force a merge past failing tests either. No extra Slack step here — it's an attended, manually-triggered run, so the skip is visible directly in the Actions output.

## Why

Previously the nightly merge ran `gh pr merge --admin`, which bypasses required status checks entirely — `config-manager-update` could (and did) get squash-merged into `main` even with failing tests. Confirmed this against a real closed PR (#2829) which shows a `fail` check despite being merged.

## Test plan

- [x] Both edited workflows validated with `actionlint` — no new issues (all pre-existing warnings are in untouched code)
- [x] `gh pr checks <PR> --json name,bucket` + jq filter tested against 4 real historical PRs (1 failing, 3 passing) — correctly classified all of them
- [x] Confirmed fail-closed behaviour on a bad/nonexistent PR lookup
- [ ] First live nightly run (or a manual `workflow_dispatch` with `dry_run: true` once `config-manager-update` next diverges) to confirm end-to-end behaviour
